### PR TITLE
Enable instrumented functions to be deepcopy'ed

### DIFF
--- a/appmap/test/data/example_class.py
+++ b/appmap/test/data/example_class.py
@@ -106,3 +106,6 @@ class ExampleClass(Super, ClassMethodMixin):
     # multiple lines
     def with_comment(self):
         return True
+
+def modfunc():
+    return 'Hello world!'

--- a/appmap/test/test_recording.py
+++ b/appmap/test/test_recording.py
@@ -85,6 +85,19 @@ class TestRecordingWhenEnabled:
         rec.start()
         with pytest.raises(RuntimeError):
             rec.start()
+    
+    def test_can_deepcopy_function(self):
+        from example_class import modfunc  # pylint: disable=import-error
+        from copy import deepcopy
+        from appmap.wrapt import FunctionWrapper
+        rec = appmap.Recording()
+        with rec:
+            f1 = deepcopy(modfunc)
+            f1()
+
+        evt = rec.events[-2]
+        assert evt.event == 'call'
+        assert evt.method_id == 'modfunc'
 
 def test_exec_module_protection(monkeypatch):
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,9 @@ packaging = "^21.3"
 # your dev environment. 
 # 
 # So, if you'd like to run the tests outside of tox,
-# you'll need to `pip install` the appropriate version of Django.
+# you'll need to `pip install` the appropriate version of Django, e.g.
+#   pip install django '~=3.2'
+#   pip install pytest-django
 
 [tool.poetry.dev-dependencies]
 httpretty = "^1.0.5"

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,16 @@
 [tox]
 isolated_build = true
-envlist = py3{7,8,9}-django{32,22}
+envlist = py37-django{2,3}, py3{8,9}-django{2,3,4}
 
 [testenv]
 deps=
     poetry>=1.2.0
     pytest-django
-    django32: Django>=3.2,<4.0
-    django22: Django>=2.2,<3.0
+    django2: Django>=2.2,<3.0
+    django3: Django>=3.2,<4.0
+    django4: Django>=4.0,<5.0
 commands =
     poetry install -v
-    django32: poetry run {posargs:pytest -v}
-    django22: poetry run pytest appmap/test/test_django.py
+    django3: poetry run {posargs:pytest -v}
+    django2: poetry run pytest appmap/test/test_django.py
+    django4: poetry run pytest appmap/test/test_django.py


### PR DESCRIPTION
Update our vendored copy of wrapt to include https://github.com/getappmap/wrapt/commit/fb8fc6c1ac75c6dad4642239f737de39be6632c2 . This fixes a problem that occurred when attempting to call `deepcopy` on an instrumented function.

These changes also fix problems when attempting to map Django projects. These problems originally looked like they were related to Django 4. It turns out that they occurred in any project using `django_filter`, e.g. [saleor](https://github.com/saleor/saleor), regardless of Django version.

The tox test matrix has now been updated to include Django 4, so.... Fixes getappmap/board#160.