### PR TITLE
Per thread recording

### DIFF
--- a/appmap/__init__.py
+++ b/appmap/__init__.py
@@ -1,8 +1,8 @@
 """AppMap recorder for Python"""
-from ._implementation.env import Env  # noqa: F401
-from ._implementation.recording import Recording, instrument_module  # noqa: F401
 from ._implementation import generation  # noqa: F401
+from ._implementation.env import Env  # noqa: F401
 from ._implementation.labels import labels  # noqa: F401
+from ._implementation.recording import Recording, instrument_module  # noqa: F401
 
 try:
     from . import flask  # noqa: F401

--- a/appmap/_implementation/__init__.py
+++ b/appmap/_implementation/__init__.py
@@ -1,8 +1,6 @@
 from . import configuration
 from . import env as appmapenv
-from . import event
-from . import metadata
-from . import recording
+from . import event, metadata, recording
 from .py_version_check import check_py_version
 
 
@@ -13,5 +11,6 @@ def initialize(**kwargs):
     recording.initialize()
     configuration.initialize()  # needs to be initialized after recording
     metadata.initialize()
+
 
 initialize()

--- a/appmap/_implementation/configuration.py
+++ b/appmap/_implementation/configuration.py
@@ -343,8 +343,8 @@ class BuiltinFilter(MatcherFilter):
 
 def initialize():
     Config().initialize()
-    Recorder().use_filter(BuiltinFilter)
-    Recorder().use_filter(ConfigFilter)
+    Recorder.use_filter(BuiltinFilter)
+    Recorder.use_filter(ConfigFilter)
 
 
 initialize()

--- a/appmap/_implementation/env.py
+++ b/appmap/_implementation/env.py
@@ -1,12 +1,13 @@
 """Initialize from the environment"""
 
-from pathlib import Path
 import logging
 import logging.config
 from os import environ
+from pathlib import Path
 
 _cwd = Path.cwd()
 _bootenv = environ.copy()
+
 
 class _EnvMeta(type):
     def __init__(cls, *args, **kwargs):
@@ -34,14 +35,13 @@ class Env(metaclass=_EnvMeta):
         if env:
             self._env.update(env)
 
-        self._root_dir = str(self._cwd) + '/'
+        self._root_dir = str(self._cwd) + "/"
         self._root_dir_len = len(self._root_dir)
 
-        output_dir = Path(self.get('APPMAP_OUTPUT_DIR', 'tmp/appmap'))
+        output_dir = Path(self.get("APPMAP_OUTPUT_DIR", "tmp/appmap"))
         self._output_dir = output_dir.resolve()
 
         self._configure_logging()
-
 
     def set(self, name, value):
         self._env[name] = value
@@ -81,42 +81,41 @@ class Env(metaclass=_EnvMeta):
 
         log_config = self.get("APPMAP_LOG_CONFIG")
         log_stream = self.get("APPMAP_LOG_STREAM", "stderr")
-        log_stream = 'ext://sys.%s' % (log_stream)
+        log_stream = "ext://sys.%s" % (log_stream)
         config_dict = {
-            'version': 1,
-            'disable_existing_loggers': False,
-            'formatters': {
-                'default': {
-                    'style': '{',
-                    'format': '[{asctime}] {levelname} {name}: {message}'
+            "version": 1,
+            "disable_existing_loggers": False,
+            "formatters": {
+                "default": {
+                    "style": "{",
+                    "format": "[{asctime}] {levelname} {name}: {message}",
                 }
             },
-            'handlers': {
-                'default': {
-                    'class': 'logging.StreamHandler',
-                    'formatter': 'default'
+            "handlers": {
+                "default": {"class": "logging.StreamHandler", "formatter": "default"}
+            },
+            "loggers": {
+                "appmap": {
+                    "level": log_level,
+                    "handlers": ["default"],
+                    "propagate": True,
                 }
             },
-            'loggers': {
-                'appmap': {
-                    'level': log_level,
-                    'handlers': ['default'],
-                    'propagate': True
-                }
-            }
         }
         if log_config is not None:
-            name, level = log_config.split('=', 2)
-            config_dict['loggers'].update({
-                name: {
-                    'level': level.upper(),
-                    'handlers': ['default'],
-                    'propagate': True
+            name, level = log_config.split("=", 2)
+            config_dict["loggers"].update(
+                {
+                    name: {
+                        "level": level.upper(),
+                        "handlers": ["default"],
+                        "propagate": True,
+                    }
                 }
-            })
+            )
         logging.config.dictConfig(config_dict)
 
 
 def initialize(**kwargs):
     Env.reset(**kwargs)
-    logging.info('appmap enabled: %s', Env.current.enabled)
+    logging.info("appmap enabled: %s", Env.current.enabled)

--- a/appmap/_implementation/generation.py
+++ b/appmap/_implementation/generation.py
@@ -1,8 +1,8 @@
 """Generate an AppMap"""
 import json
 
-from .metadata import Metadata
 from .event import Event
+from .metadata import Metadata
 
 
 # ClassMapDict needs to quack a little like a dict. If it's actually a
@@ -34,32 +34,33 @@ class ClassMapEntry:
 
 class PackageEntry(ClassMapEntry):
     def __init__(self, name):
-        super().__init__(name, 'package')
+        super().__init__(name, "package")
         self.children = ClassMapDict()
 
 
 class ClassEntry(ClassMapEntry):
     def __init__(self, name):
-        super().__init__(name, 'class')
+        super().__init__(name, "class")
         self.children = ClassMapDict()
 
 
 class FuncEntry(ClassMapEntry):
     def __init__(self, e):
-        super().__init__(e.method_id, 'function')
-        self.location = '%s:%s' % (e.path, e.lineno)
+        super().__init__(e.method_id, "function")
+        self.location = "%s:%s" % (e.path, e.lineno)
         self.static = e.static
         self.labels = e.labels
         self.comment = e.comment
+
 
 def classmap(recording):
     ret = ClassMapDict()
     for e in recording.events:
         try:
-            if e.event != 'call':
+            if e.event != "call":
                 continue
 
-            packages, *classes = e.defined_class.rsplit('.', 1)
+            packages, *classes = e.defined_class.rsplit(".", 1)
             # If there's only a single component in the name
             # (e.g. it's a module name), use it as a class.
             if len(classes) == 0:
@@ -67,7 +68,7 @@ def classmap(recording):
                 packages = []
             else:
                 class_ = classes[0]
-                packages = packages.split('.')
+                packages = packages.split(".")
 
             children = ret
             for p in packages:
@@ -77,7 +78,7 @@ def classmap(recording):
             entry = children.setdefault(class_, ClassEntry(class_))
             children = entry.children
 
-            loc = '%s:%s' % (e.path, e.lineno)
+            loc = "%s:%s" % (e.path, e.lineno)
             children.setdefault(loc, FuncEntry(e))
         except AttributeError:
             # Event might not have a defined_class attribute;
@@ -94,10 +95,10 @@ def appmap(recording, metadata):
         appmap_metadata.update(metadata)
 
     return {
-        'version': '1.4',
-        'metadata': appmap_metadata,
-        'events': recording.events,
-        'classMap': list(classmap(recording).values())
+        "version": "1.4",
+        "metadata": appmap_metadata,
+        "events": recording.events,
+        "classMap": list(classmap(recording).values()),
     }
 
 

--- a/appmap/_implementation/instrument.py
+++ b/appmap/_implementation/instrument.py
@@ -85,7 +85,7 @@ def call_instrumented(f, instance, args, kwargs):
         params = CallEvent.set_params(f.params, instance, args, kwargs)
         call_event = f.make_call_event(parameters=params)
     call_event_id = call_event.id
-    Recorder().add_event(call_event)
+    Recorder.add_event(call_event)
     start_time = time.time()
     try:
         ret = f.fn(*args, **kwargs)
@@ -94,11 +94,11 @@ def call_instrumented(f, instance, args, kwargs):
         return_event = event.FuncReturnEvent(return_value=ret,
                                              parent_id=call_event_id,
                                              elapsed=elapsed_time)
-        Recorder().add_event(return_event)
+        Recorder.add_event(return_event)
         return ret
     except Exception:  # noqa: E722
         elapsed_time = time.time() - start_time
-        Recorder().add_event(event.ExceptionEvent(parent_id=call_event_id,
+        Recorder.add_event(event.ExceptionEvent(parent_id=call_event_id,
                                                   elapsed=elapsed_time,
                                                   exc_info=sys.exc_info()))
         raise

--- a/appmap/_implementation/labels.py
+++ b/appmap/_implementation/labels.py
@@ -11,7 +11,7 @@ class labels:
     def __call__(self, fn):
         # For simplicity, set _appmap_labels right on the
         # function. We'll delete it when we instrument the function.
-        setattr(fn, '_appmap_labels', self._labels)
+        setattr(fn, "_appmap_labels", self._labels)
         return fn
 
 
@@ -21,16 +21,16 @@ Config = Dict[Label, Union[FunctionName, List[FunctionName]]]
 
 
 class LabelSet:
-    """ A set of labels defined to be applied on specific functions. """
+    """A set of labels defined to be applied on specific functions."""
 
     def __init__(self, config: Optional[Config] = None):
-        """ Create the LabelSet, optionally pre-populating it with the provided config. """
+        """Create the LabelSet, optionally pre-populating it with the provided config."""
         self.labels = defaultdict(list)
         if config:
             self.append(config)
 
     def append(self, config: Config):
-        """ Update this LabelSet to contain definitions from the config. """
+        """Update this LabelSet to contain definitions from the config."""
         for label, functions in config.items():
             if isinstance(functions, str):
                 functions = (functions,)
@@ -38,8 +38,8 @@ class LabelSet:
                 self.labels[function].append(label)
 
     def apply(self, function: Filterable) -> Optional[List[Label]]:
-        """ Searches the labelset for the function and applies any applicable labels.
-        Returns them. """
+        """Searches the labelset for the function and applies any applicable labels.
+        Returns them."""
         applicable = self.labels.get(function.fqname, None)
         if not applicable:
             return None
@@ -48,9 +48,9 @@ class LabelSet:
 
     def __repr__(self):
         if not self.labels:
-            return 'LabelSet()'
+            return "LabelSet()"
         inverted = defaultdict(list)
         for function, labels in self.labels.items():
             for label in labels:
                 inverted[label].append(function)
-        return 'LabelSet(%s)' % dict(inverted)
+        return "LabelSet(%s)" % dict(inverted)

--- a/appmap/_implementation/metadata.py
+++ b/appmap/_implementation/metadata.py
@@ -1,9 +1,9 @@
 """Shared metadata gathering"""
 
-from functools import lru_cache
 import logging
 import platform
 import re
+from functools import lru_cache
 
 from . import utils
 from .env import Env
@@ -17,7 +17,7 @@ def _lines(text):
 
     Returns None if the result would be empty."""
 
-    lines = [x for x in map(lambda x: x.strip(), text.split('\n')) if len(x) > 0]
+    lines = [x for x in map(lambda x: x.strip(), text.split("\n")) if len(x) > 0]
     if len(lines) == 0:
         return None
     return lines
@@ -30,54 +30,51 @@ class Metadata(dict):
         super().__init__(self.base(root_dir or Env.current.root_dir))
 
         if any(self.__class__.frameworks):
-            self['frameworks'] = self.__class__.frameworks
+            self["frameworks"] = self.__class__.frameworks
             self.reset()
 
-
     frameworks = []
+
     @classmethod
     def add_framework(cls, name, version=None):
         """Add a framework that will end up (only) in the next Metadata() created.
 
         Duplicate entries are ignored.
         """
-        if not any(f['name'] == name for f in cls.frameworks):
-            cls.frameworks.append(compact_dict({'name': name, 'version': version}))
-
+        if not any(f["name"] == name for f in cls.frameworks):
+            cls.frameworks.append(compact_dict({"name": name, "version": version}))
 
     @classmethod
     def reset(cls):
         """Resets stored framework metadata."""
         cls.frameworks = []
 
-
     @staticmethod
     @lru_cache()
     def base(root_dir):
         """Gathers git and platform metadata given the project root directory path."""
         metadata = {
-            'language': {
-                'name': 'python',
-                'engine': platform.python_implementation(),
-                'version': platform.python_version()
+            "language": {
+                "name": "python",
+                "engine": platform.python_implementation(),
+                "version": platform.python_version(),
             },
-            'client': {
-                'name': 'appmap',
-                'url': 'https://github.com/applandinc/appmap-python'
-            }
+            "client": {
+                "name": "appmap",
+                "url": "https://github.com/applandinc/appmap-python",
+            },
         }
 
         if Metadata._git_available(root_dir):
-            metadata.update({'git': Metadata._git_metadata(root_dir)})
+            metadata.update({"git": Metadata._git_metadata(root_dir)})
 
         return metadata
-
 
     @staticmethod
     @lru_cache()
     def _git_available(root_dir):
         try:
-            ret = utils.subprocess_run(['git', 'status'], cwd=root_dir)
+            ret = utils.subprocess_run(["git", "status"], cwd=root_dir)
             if not ret.returncode:
                 return True
             logger.warning("Failed running 'git status', %s", ret.stderr)
@@ -95,42 +92,44 @@ class Metadata(dict):
 
         return False
 
-
     @staticmethod
     @lru_cache()
     def _git_metadata(root_dir):
         git = utils.git(cwd=root_dir)
-        repository = git('config --get remote.origin.url')
-        branch = git('rev-parse --abbrev-ref HEAD')
-        commit = git('rev-parse HEAD')
-        status = _lines(git('status -s'))
-        annotated_tag = git('describe --abbrev=0') or None
-        tag = git('describe --abbrev=0 --tags') or None
+        repository = git("config --get remote.origin.url")
+        branch = git("rev-parse --abbrev-ref HEAD")
+        commit = git("rev-parse HEAD")
+        status = _lines(git("status -s"))
+        annotated_tag = git("describe --abbrev=0") or None
+        tag = git("describe --abbrev=0 --tags") or None
 
-        pattern = re.compile(r'.*-(\d+)-\w+$')
+        pattern = re.compile(r".*-(\d+)-\w+$")
 
         commits_since_annotated_tag = None
         if annotated_tag:
-            result = pattern.search(git('describe'))
+            result = pattern.search(git("describe"))
             if result:
                 commits_since_annotated_tag = int(result.group(1))
 
         commits_since_tag = None
         if tag:
-            result = pattern.search(git('describe --tags'))
+            result = pattern.search(git("describe --tags"))
             if result:
                 commits_since_tag = int(result.group(1))
 
-        return compact_dict({
-            'repository': repository,
-            'branch': branch,
-            'commit': commit,
-            'status': status,
-            'tag': tag,
-            'annotated_tag': annotated_tag,
-            'commits_since_tag': commits_since_tag,
-            'commits_since_annotated_tag': commits_since_annotated_tag
-        })
+        return compact_dict(
+            {
+                "repository": repository,
+                "branch": branch,
+                "commit": commit,
+                "status": status,
+                "tag": tag,
+                "annotated_tag": annotated_tag,
+                "commits_since_tag": commits_since_tag,
+                "commits_since_annotated_tag": commits_since_annotated_tag,
+            }
+        )
+
 
 def initialize():
     Metadata.reset()

--- a/appmap/_implementation/py_version_check.py
+++ b/appmap/_implementation/py_version_check.py
@@ -11,13 +11,15 @@ class AppMapPyVerException(Exception):
 def _get_py_version():
     return sys.version_info
 
+
 def _get_platform_version():
     return platform.python_version()
+
 
 def check_py_version():
     req = (3, 6)
     actual = _get_platform_version()
     if _get_py_version() < req:
         raise AppMapPyVerException(
-            f'Minimum Python version supported is {req[0]}.{req[1]}, found {actual}'
+            f"Minimum Python version supported is {req[0]}.{req[1]}, found {actual}"
         )

--- a/appmap/_implementation/web_framework.py
+++ b/appmap/_implementation/web_framework.py
@@ -3,32 +3,31 @@
 import re
 import time
 
-from appmap._implementation.event import (
-    describe_value,
-    Event,
-    ReturnEvent,
-)
+from appmap._implementation.event import Event, ReturnEvent, describe_value
 from appmap._implementation.recording import Recorder
 from appmap._implementation.utils import root_relative_path
 
 
 class TemplateEvent(Event):  # pylint: disable=too-few-public-methods
     """A special call event that records template rendering."""
-    __slots__ = ['receiver', 'path']
+
+    __slots__ = ["receiver", "path"]
 
     def __init__(self, path, instance=None):
-        super().__init__('call')
+        super().__init__("call")
         self.receiver = describe_value(instance)
         self.path = root_relative_path(path)
 
     def to_dict(self, attrs=None):
         result = super().to_dict(attrs)
-        classlike_name = re.sub(r'\W', '', self.path.title())
-        result.update({
-            'defined_class': f'<templates>.{classlike_name}',
-            'method_id': 'render',
-            'static': False,
-        })
+        classlike_name = re.sub(r"\W", "", self.path.title())
+        result.update(
+            {
+                "defined_class": f"<templates>.{classlike_name}",
+                "method_id": "render",
+                "static": False,
+            }
+        )
         return result
 
 
@@ -40,6 +39,7 @@ class TemplateHandler:  # pylint: disable=too-few-public-methods
     which has a .render() method. Note it requires a .filename property; if
     there is no such property, this handler can be subclassed first to provide it.
     """
+
     def render(self, orig, *args, **kwargs):
         """Calls the original implementation.
 
@@ -55,6 +55,4 @@ class TemplateHandler:  # pylint: disable=too-few-public-methods
             return orig(self, *args, **kwargs)
         finally:
             if rec.enabled:
-                Recorder.add_event(
-                    ReturnEvent(call_event.id, time.monotonic() - start)
-                )
+                Recorder.add_event(ReturnEvent(call_event.id, time.monotonic() - start))

--- a/appmap/_implementation/web_framework.py
+++ b/appmap/_implementation/web_framework.py
@@ -50,11 +50,11 @@ class TemplateHandler:  # pylint: disable=too-few-public-methods
         if rec.enabled:
             start = time.monotonic()
             call_event = TemplateEvent(self.filename, self)  # pylint: disable=no-member
-            rec.add_event(call_event)
+            Recorder.add_event(call_event)
         try:
             return orig(self, *args, **kwargs)
         finally:
             if rec.enabled:
-                rec.add_event(
+                Recorder.add_event(
                     ReturnEvent(call_event.id, time.monotonic() - start)
                 )

--- a/appmap/command/appmap_agent_init.py
+++ b/appmap/command/appmap_agent_init.py
@@ -1,22 +1,28 @@
 import json
 import logging
 import os
-from pathlib import Path
 import sys
+from pathlib import Path
 
 import yaml
 
 from .._implementation.configuration import Config
 
+
 def _run():
-    print(json.dumps({
-        'configuration': {
-            'filename': 'appmap.yml',
-            'contents': yaml.dump(Config().default)
-        }
-    }))
+    print(
+        json.dumps(
+            {
+                "configuration": {
+                    "filename": "appmap.yml",
+                    "contents": yaml.dump(Config().default),
+                }
+            }
+        )
+    )
 
     return 0
+
 
 def run():
     sys.exit(_run())

--- a/appmap/command/appmap_agent_validate.py
+++ b/appmap/command/appmap_agent_validate.py
@@ -1,13 +1,14 @@
 import json
 import sys
 
-from packaging.version import Version, parse
 from importlib_metadata import PackageNotFoundError, version
+from packaging.version import Version, parse
 
-from .._implementation.py_version_check import check_py_version, AppMapPyVerException
+from .._implementation.py_version_check import AppMapPyVerException, check_py_version
+
 
 class ValidationFailure(Exception):
-    def __init__(self, message, level='error', detailed_message=None, help_urls=None):
+    def __init__(self, message, level="error", detailed_message=None, help_urls=None):
         self.message = message
         self.level = level
         self.detailed_message = detailed_message
@@ -23,6 +24,7 @@ def check_python_version():
     except AppMapPyVerException as e:
         raise ValidationFailure(str(e))
 
+
 def _check_version(dist, v):
     dist_version = None
     try:
@@ -32,40 +34,49 @@ def _check_version(dist, v):
         actual = parse(dist_version)
 
         if actual < required:
-            raise ValidationFailure(f'{dist} must have version >= {required}, found {actual}')
+            raise ValidationFailure(
+                f"{dist} must have version >= {required}, found {actual}"
+            )
     except PackageNotFoundError:
         pass
 
     return dist_version
 
+
 # Note that, per https://www.python.org/dev/peps/pep-0426/#name,
 # comparison of distribution names are case-insensitive.
 def check_django_version():
-    return _check_version('django', '3.2')
+    return _check_version("django", "3.2")
+
 
 def check_flask_version():
-    return _check_version('flask', '1.1')
+    return _check_version("flask", "1.1")
+
 
 def check_pytest_version():
-    return _check_version('pytest', '6.2')
+    return _check_version("pytest", "6.2")
+
 
 def _run():
-    errors = [ValidationFailure('internal error')] # shouldn't ever see this
+    errors = [ValidationFailure("internal error")]  # shouldn't ever see this
     try:
         check_python_version()
         django_version = check_django_version()
         flask_version = check_flask_version()
         if not (django_version or flask_version):
-            raise ValidationFailure(f'No web framework found. Expected one of: Django, Flask')
+            raise ValidationFailure(
+                f"No web framework found. Expected one of: Django, Flask"
+            )
 
         check_pytest_version()
         errors = []
     except ValidationFailure as e:
-        errors = [ e ]
+        errors = [e]
 
-    print(json.dumps([e.to_dict() for e in errors] , indent=2))
+    print(json.dumps([e.to_dict() for e in errors], indent=2))
 
     return 0 if len(errors) == 0 else 1
+
 
 def run():
     sys.exit(_run())

--- a/appmap/django.py
+++ b/appmap/django.py
@@ -5,22 +5,22 @@ add appmap.django.Middleware to MIDDLEWARE in your app configuration
 and run with APPMAP=true set in the environment.
 """
 
+import json
+import re
+import sys
+import time
+
 import django
-from django.core.handlers.base import BaseHandler
 from django.conf import settings
-from django.db.backends.utils import CursorDebugWrapper
+from django.core.handlers.base import BaseHandler
 from django.db.backends.signals import connection_created
+from django.db.backends.utils import CursorDebugWrapper
 from django.dispatch import receiver
 from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
 from django.template import Template
 from django.urls import get_resolver, resolve
-from django.urls.resolvers import _route_to_regex
 from django.urls.exceptions import Resolver404
-
-import time
-import json
-import re
-import sys
+from django.urls.resolvers import _route_to_regex
 
 from appmap._implementation import generation
 from appmap._implementation.env import Env
@@ -32,10 +32,11 @@ from appmap._implementation.event import (
     SqlEvent,
 )
 from appmap._implementation.instrument import is_instrumentation_disabled
-from appmap._implementation.web_framework import TemplateHandler as BaseTemplateHandler
-from ._implementation.metadata import Metadata
 from appmap._implementation.recording import Recorder
-from ._implementation.utils import values_dict, patch_class
+from appmap._implementation.web_framework import TemplateHandler as BaseTemplateHandler
+
+from ._implementation.metadata import Metadata
+from ._implementation.utils import patch_class, values_dict
 
 
 def parse_pg_version(version):
@@ -46,20 +47,20 @@ def parse_pg_version(version):
 def database_version(connection):
     """Examine a database connection and try to establish the backend version."""
     vendor = connection.vendor
-    if vendor == 'sqlite':
+    if vendor == "sqlite":
         return connection.Database.sqlite_version_info
-    if vendor == 'mysql':
+    if vendor == "mysql":
         return connection.mysql_version
-    if vendor == 'postgresql':
+    if vendor == "postgresql":
         return parse_pg_version(connection.pg_version)
-    if vendor == 'oracle':
+    if vendor == "oracle":
         return connection.oracle_version
     return None
 
 
 def add_metadata():
     """Adds Django framework to metadata for the next appmap generation."""
-    Metadata.add_framework('Django', django.get_version())
+    Metadata.add_framework("Django", django.get_version())
 
 
 class ExecuteWrapper:
@@ -79,7 +80,7 @@ class ExecuteWrapper:
                 add_metadata()
                 stop = time.monotonic()
                 duration = stop - start
-                conn = context['connection']
+                conn = context["connection"]
                 # Note this logic is based on django.db.backends.utils.CursorDebugWrapper.
                 if many:
                     # Sometimes the same query is executed with different parameter sets.
@@ -87,12 +88,14 @@ class ExecuteWrapper:
                     try:
                         times = len(params)
                     except TypeError:
-                        times = '?'
-                    sql = '%s times %s' % (times, sql)
+                        times = "?"
+                    sql = "%s times %s" % (times, sql)
                 else:
-                    cursor = context['cursor']
+                    cursor = context["cursor"]
                     sql = conn.ops.last_executed_query(cursor, sql, params)
-                call_event = SqlEvent(sql, vendor=conn.vendor, version=database_version(conn))
+                call_event = SqlEvent(
+                    sql, vendor=conn.vendor, version=database_version(conn)
+                )
                 Recorder.add_event(call_event)
                 return_event = ReturnEvent(parent_id=call_event.id, elapsed=duration)
                 Recorder.add_event(return_event)
@@ -104,12 +107,14 @@ class ExecuteWrapper:
 
 original_execute = CursorDebugWrapper.execute
 
+
 def wrapped_execute(self, sql, params=None):
     """Directly execute the query if instrumentation is temporarily
     disabled, to avoid capturing queries not issued by the application."""
     if is_instrumentation_disabled():
         return super().execute(sql, params)
     return original_execute(self, sql, params)
+
 
 CursorDebugWrapper.execute = wrapped_execute
 
@@ -135,7 +140,7 @@ def request_params(request):
     params = request.GET.copy()
     params.update(request.POST)
 
-    if request.content_type == 'application/json':
+    if request.content_type == "application/json":
         try:
             # Note: it's important to use request.body here instead of
             # directly reading request. This way the application can still
@@ -145,6 +150,7 @@ def request_params(request):
             pass  # invalid json or not an object
 
     return values_dict(params.lists())
+
 
 def get_resolved_match(path_info, resolver):
     resolver_match = resolver.resolve(path_info)
@@ -162,16 +168,19 @@ def get_resolved_match(path_info, resolver):
     # If it didn't match, it's a url pattern. Use _route_to_regex to
     # turn it into a regex.  (url patterns sometimes start with a
     # caret, which needs to be stripped before conversion.)
-    if regex[0] == '^':
+    if regex[0] == "^":
         regex = regex[1:]
     regex = _route_to_regex(regex)[0]
 
     match = re.match(regex, path_info[1:])
     if not match:
-        raise RuntimeError('No match for %s found with resolver %r, regex %s' %
-                           (path_info, resolver, regex))
+        raise RuntimeError(
+            "No match for %s found with resolver %r, regex %s"
+            % (path_info, resolver, regex)
+        )
 
     return (regex, match)
+
 
 def normalize_path_info(path_info, resolved):
     if not resolved.kwargs:
@@ -186,16 +195,17 @@ def normalize_path_info(path_info, resolved):
 
     # For each parameter, insert the portion of the path that precedes
     # it, followed by the name of the parameter.
-    np = '/'
+    np = "/"
     pos = 0
-    for i,g in enumerate(groups):
-        np += match.string[pos:match.start(i+1)]
-        np += f'{{{g}}}'
-        pos = match.end(i+1)
+    for i, g in enumerate(groups):
+        np += match.string[pos : match.start(i + 1)]
+        np += f"{{{g}}}"
+        pos = match.end(i + 1)
 
     # Finally, append anything remaining in the path
     np += match.string[pos:]
     return np
+
 
 class Middleware:
     def __init__(self, get_response):
@@ -206,7 +216,7 @@ class Middleware:
         if not Env.current.enabled:
             return self.get_response(request)
 
-        if request.path_info == '/_appmap/record':
+        if request.path_info == "/_appmap/record":
             return self.recording(request)
         if self.recorder.enabled:
             add_metadata()
@@ -226,8 +236,8 @@ class Middleware:
                 path_info=request.path_info,
                 message_parameters=params,
                 normalized_path_info=normalized_path_info,
-                protocol=request.META['SERVER_PROTOCOL'],
-                headers=request.headers
+                protocol=request.META["SERVER_PROTOCOL"],
+                headers=request.headers,
             )
             Recorder.add_event(call_event)
 
@@ -237,9 +247,7 @@ class Middleware:
             if self.recorder.enabled:
                 duration = time.monotonic() - start
                 exception_event = ExceptionEvent(
-                    parent_id=call_event.id,
-                    elapsed=duration,
-                    exc_info=sys.exc_info()
+                    parent_id=call_event.id, elapsed=duration, exc_info=sys.exc_info()
                 )
                 Recorder.add_event(exception_event)
             raise
@@ -250,7 +258,7 @@ class Middleware:
                 parent_id=call_event.id,
                 elapsed=duration,
                 status_code=response.status_code,
-                headers=dict(response.items())
+                headers=dict(response.items()),
             )
             Recorder.add_event(return_event)
 
@@ -258,33 +266,31 @@ class Middleware:
 
     def recording(self, request):
         """Handle recording requests."""
-        if request.method == 'GET':
-            return JsonResponse({'enabled': self.recorder.enabled})
-        if request.method == 'POST':
+        if request.method == "GET":
+            return JsonResponse({"enabled": self.recorder.enabled})
+        if request.method == "POST":
             if self.recorder.enabled:
-                return HttpResponse('Recording is already in progress', status=409)
+                return HttpResponse("Recording is already in progress", status=409)
             self.recorder.clear()
             self.recorder.start_recording()
             return HttpResponse()
 
-        if request.method == 'DELETE':
+        if request.method == "DELETE":
             if not self.recorder.enabled:
-                return HttpResponse('No recording is in progress', status=404)
+                return HttpResponse("No recording is in progress", status=404)
 
             self.recorder.stop_recording()
             return HttpResponse(
-                generation.dump(self.recorder),
-                content_type='application/json'
+                generation.dump(self.recorder), content_type="application/json"
             )
-
 
         return HttpResponseBadRequest()
 
 
 def inject_middleware():
     """Make sure AppMap middleware is added to the stack"""
-    if 'appmap.django.Middleware' not in settings.MIDDLEWARE:
-        settings.MIDDLEWARE.insert(0, 'appmap.django.Middleware')
+    if "appmap.django.Middleware" not in settings.MIDDLEWARE:
+        settings.MIDDLEWARE.insert(0, "appmap.django.Middleware")
 
 
 original_load_middleware = BaseHandler.load_middleware
@@ -294,6 +300,7 @@ def load_middleware(*args, **kwargs):
     """Patched wrapper to inject AppMap middleware first"""
     inject_middleware()
     return original_load_middleware(*args, **kwargs)
+
 
 BaseHandler.load_middleware = load_middleware
 

--- a/appmap/django.py
+++ b/appmap/django.py
@@ -93,9 +93,9 @@ class ExecuteWrapper:
                     cursor = context['cursor']
                     sql = conn.ops.last_executed_query(cursor, sql, params)
                 call_event = SqlEvent(sql, vendor=conn.vendor, version=database_version(conn))
-                self.recorder.add_event(call_event)
+                Recorder.add_event(call_event)
                 return_event = ReturnEvent(parent_id=call_event.id, elapsed=duration)
-                self.recorder.add_event(return_event)
+                Recorder.add_event(return_event)
 
 
 # CursorDebugWrapper is used in tests to capture and examine queries.
@@ -229,7 +229,7 @@ class Middleware:
                 protocol=request.META['SERVER_PROTOCOL'],
                 headers=request.headers
             )
-            self.recorder.add_event(call_event)
+            Recorder.add_event(call_event)
 
         try:
             response = self.get_response(request)
@@ -241,7 +241,7 @@ class Middleware:
                     elapsed=duration,
                     exc_info=sys.exc_info()
                 )
-                self.recorder.add_event(exception_event)
+                Recorder.add_event(exception_event)
             raise
 
         if self.recorder.enabled:
@@ -252,7 +252,7 @@ class Middleware:
                 status_code=response.status_code,
                 headers=dict(response.items())
             )
-            self.recorder.add_event(return_event)
+            Recorder.add_event(return_event)
 
         return response
 

--- a/appmap/flask.py
+++ b/appmap/flask.py
@@ -102,7 +102,7 @@ class AppmapFlask:
                 protocol=request.environ.get('SERVER_PROTOCOL'),
                 headers=request.headers
             )
-            Recorder().add_event(call_event)
+            Recorder.add_event(call_event)
 
             appctx = _app_ctx_stack.top
             appctx.appmap_request_event = call_event
@@ -120,7 +120,7 @@ class AppmapFlask:
                 status_code=response.status_code,
                 headers=response.headers
             )
-            Recorder().add_event(return_event)
+            Recorder.add_event(return_event)
 
         return response
 

--- a/appmap/flask.py
+++ b/appmap/flask.py
@@ -1,22 +1,22 @@
-from functools import wraps
 import json
 import time
+from functools import wraps
 
 import flask
 import flask.cli
-from flask import _app_ctx_stack, request
 import jinja2
-from werkzeug.routing import parse_rule
+from flask import _app_ctx_stack, request
 from werkzeug.exceptions import BadRequest
+from werkzeug.routing import parse_rule
 
-from appmap._implementation.env import Env
 from appmap._implementation import generation
+from appmap._implementation.env import Env
 from appmap._implementation.event import HttpServerRequestEvent, HttpServerResponseEvent
-from appmap._implementation.web_framework import TemplateHandler as BaseTemplateHandler
-from ._implementation.metadata import Metadata
 from appmap._implementation.recording import Recorder, Recording
-from ._implementation.utils import values_dict, patch_class
+from appmap._implementation.web_framework import TemplateHandler as BaseTemplateHandler
 
+from ._implementation.metadata import Metadata
+from ._implementation.utils import patch_class, values_dict
 
 try:
     # pylint: disable=unused-import
@@ -56,29 +56,44 @@ class AppmapFlask:
 
         self.recording = Recording()
 
-        self.record_url = '/_appmap/record'
+        self.record_url = "/_appmap/record"
 
         # print('in init_app')
-        app.add_url_rule(self.record_url, 'appmap_record_get', view_func=self.record_get, methods=['GET'])
-        app.add_url_rule(self.record_url, 'appmap_record_post', view_func=self.record_post, methods=['POST'])
-        app.add_url_rule(self.record_url, 'appmap_record_delete', view_func=self.record_delete, methods=['DELETE'])
+        app.add_url_rule(
+            self.record_url,
+            "appmap_record_get",
+            view_func=self.record_get,
+            methods=["GET"],
+        )
+        app.add_url_rule(
+            self.record_url,
+            "appmap_record_post",
+            view_func=self.record_post,
+            methods=["POST"],
+        )
+        app.add_url_rule(
+            self.record_url,
+            "appmap_record_delete",
+            view_func=self.record_delete,
+            methods=["DELETE"],
+        )
 
         app.before_request(self.before_request)
         app.after_request(self.after_request)
 
     def record_get(self):
-        return {'enabled': self.recording.is_running()}
+        return {"enabled": self.recording.is_running()}
 
     def record_post(self):
         if self.recording.is_running():
-            return 'Recording is already in progress', 409
+            return "Recording is already in progress", 409
 
         self.recording.start()
-        return '', 200
+        return "", 200
 
     def record_delete(self):
         if not self.recording.is_running():
-            return 'No recording is in progress', 404
+            return "No recording is in progress", 404
 
         self.recording.stop()
 
@@ -86,21 +101,25 @@ class AppmapFlask:
 
     def before_request(self):
         if self.recording.is_running() and request.path != self.record_url:
-            Metadata.add_framework('flask', flask.__version__)
+            Metadata.add_framework("flask", flask.__version__)
             np = None
             # See
             # https://github.com/pallets/werkzeug/blob/2.0.0/src/werkzeug/routing.py#L213
             # for a description of parse_rule.
             if request.url_rule:
-                np = ''.join([f'{{{p}}}' if c else p
-                              for c,_,p in parse_rule(request.url_rule.rule)])
+                np = "".join(
+                    [
+                        f"{{{p}}}" if c else p
+                        for c, _, p in parse_rule(request.url_rule.rule)
+                    ]
+                )
             call_event = HttpServerRequestEvent(
                 request_method=request.method,
                 path_info=request.path,
                 message_parameters=request_params(request),
                 normalized_path_info=np,
-                protocol=request.environ.get('SERVER_PROTOCOL'),
-                headers=request.headers
+                protocol=request.environ.get("SERVER_PROTOCOL"),
+                headers=request.headers,
             )
             Recorder.add_event(call_event)
 
@@ -118,7 +137,7 @@ class AppmapFlask:
                 parent_id=parent_id,
                 elapsed=duration,
                 status_code=response.status_code,
-                headers=response.headers
+                headers=response.headers,
             )
             Recorder.add_event(return_event)
 
@@ -139,6 +158,7 @@ def wrap_cli_fn(fn):
             appmap_flask = AppmapFlask()
             appmap_flask.init_app(app)
         return app
+
     return install_middleware
 
 

--- a/appmap/http.py
+++ b/appmap/http.py
@@ -65,13 +65,13 @@ class HTTPConnectionPatch:
 
         recorder = Recorder()
         if recorder.enabled:
-            recorder.add_event(event)
+            Recorder.add_event(event)
 
         start = time.monotonic()
         response = orig(self)
 
         if recorder.enabled:
-            recorder.add_event(HttpClientResponseEvent(
+            Recorder.add_event(HttpClientResponseEvent(
                 response.status,
                 headers=response.headers,
                 elapsed=(time.monotonic() - start),

--- a/appmap/http.py
+++ b/appmap/http.py
@@ -4,20 +4,20 @@ Importing this module patches http.client.HTTPConnection to record
 appmap events of any HTTP requests.
 """
 
-from http.client import HTTPConnection
 import time
-from urllib.parse import urlsplit, parse_qs
+from http.client import HTTPConnection
+from urllib.parse import parse_qs, urlsplit
 
 from ._implementation.event import HttpClientRequestEvent, HttpClientResponseEvent
 from ._implementation.recording import Recorder
-from ._implementation.utils import values_dict, patch_class
+from ._implementation.utils import patch_class, values_dict
 
 
 def is_secure(self: HTTPConnection):
     """Checks whether HTTP connection is secure."""
     # isinstance(self, HTTPSConnection) won't work with
     # eg. urllib3 HTTPConnection. Instead try duck typing.
-    return hasattr(self, 'key_file')
+    return hasattr(self, "key_file")
 
 
 def base_url(self: HTTPConnection):
@@ -25,9 +25,9 @@ def base_url(self: HTTPConnection):
 
     Example result: https://appmap.example:3000
     """
-    scheme = 'https' if is_secure(self) else 'http'
-    port = '' if self.port == self.default_port else f':{self.port}'
-    return f'{scheme}://{self.host}{port}'
+    scheme = "https" if is_secure(self) else "http"
+    port = "" if self.port == self.default_port else f":{self.port}"
+    return f"{scheme}://{self.host}{port}"
 
 
 # pylint: disable=missing-function-docstring
@@ -36,21 +36,22 @@ class HTTPConnectionPatch:
     """Patch methods for HTTPConnection, building and recording appmap events
     as requests are issues and responses received.
     """
+
     # pylint: disable=attribute-defined-outside-init
     def putrequest(self, orig, method, url, *args, **kwargs):
         split = urlsplit(url)
         self._appmap_request = HttpClientRequestEvent(
             method,
             base_url(self) + split.path,
-            values_dict(parse_qs(split.query).items())
+            values_dict(parse_qs(split.query).items()),
         )
         orig(self, method, url, *args, **kwargs)
 
     def putheader(self, orig, header, *values):
         request = self._appmap_request.http_client_request
-        if not hasattr(request, 'headers'):
-            request['headers'] = {}
-        headers = request['headers']
+        if not hasattr(request, "headers"):
+            request["headers"] = {}
+        headers = request["headers"]
         if not header in headers:
             headers[header] = []
         headers[header].extend(values)
@@ -60,8 +61,8 @@ class HTTPConnectionPatch:
         event = self._appmap_request
         del self._appmap_request
         request = event.http_client_request
-        if 'headers' in request:
-            request['headers'] = values_dict(request['headers'].items())
+        if "headers" in request:
+            request["headers"] = values_dict(request["headers"].items())
 
         recorder = Recorder()
         if recorder.enabled:
@@ -71,11 +72,13 @@ class HTTPConnectionPatch:
         response = orig(self)
 
         if recorder.enabled:
-            Recorder.add_event(HttpClientResponseEvent(
-                response.status,
-                headers=response.headers,
-                elapsed=(time.monotonic() - start),
-                parent_id=event.id
-            ))
+            Recorder.add_event(
+                HttpClientResponseEvent(
+                    response.status,
+                    headers=response.headers,
+                    elapsed=(time.monotonic() - start),
+                    parent_id=event.id,
+                )
+            )
 
         return response

--- a/appmap/labeling/__init__.py
+++ b/appmap/labeling/__init__.py
@@ -3,15 +3,16 @@ For consistency, the labels are defined in YAML data files in this module,
 structured exactly like the labels section in appmap.yml.
 """
 
-from importlib_resources import files
 import yaml
+from importlib_resources import files
 
 from .._implementation.labels import LabelSet
 
+
 def presets() -> LabelSet:
-    """ Load the LabelSet of the presets included with appmap-python. """
+    """Load the LabelSet of the presets included with appmap-python."""
     labels = LabelSet()
     for resource in files(__name__).iterdir():
-        if resource.suffix == '.yml':
+        if resource.suffix == ".yml":
             labels.append(yaml.safe_load(resource.read_text()))
     return labels

--- a/appmap/sqlalchemy.py
+++ b/appmap/sqlalchemy.py
@@ -35,7 +35,7 @@ def capture_sql_call(conn, cursor, statement, parameters, context, executemany):
             sql = statement
         dialect = conn.dialect
         call_event = SqlEvent(sql, vendor=dialect.name, version=dialect.server_version_info)
-        recorder.add_event(call_event)
+        Recorder.add_event(call_event)
         setattr(
             context, 'appmap',
             { 'start_time': time.monotonic(), 'call_event_id': call_event.id }
@@ -56,4 +56,4 @@ def capture_sql(conn, cursor, statement, parameters, context, executemany):
         duration = stop - context.appmap['start_time']
         return_event = ReturnEvent(parent_id=context.appmap['call_event_id'], elapsed=duration)
         del context.appmap
-        recorder.add_event(return_event)
+        Recorder.add_event(return_event)

--- a/appmap/sqlalchemy.py
+++ b/appmap/sqlalchemy.py
@@ -6,13 +6,14 @@ import sqlalchemy
 from sqlalchemy import event
 from sqlalchemy.engine import Engine
 
-from appmap._implementation.event import SqlEvent, ReturnEvent
+from appmap._implementation.event import ReturnEvent, SqlEvent
 from appmap._implementation.instrument import is_instrumentation_disabled
-from ._implementation.metadata import Metadata
 from appmap._implementation.recording import Recorder
 
+from ._implementation.metadata import Metadata
 
-@event.listens_for(Engine, 'before_cursor_execute')
+
+@event.listens_for(Engine, "before_cursor_execute")
 # pylint: disable=too-many-arguments,unused-argument
 def capture_sql_call(conn, cursor, statement, parameters, context, executemany):
     """Capture SQL query callinto appmap."""
@@ -22,27 +23,30 @@ def capture_sql_call(conn, cursor, statement, parameters, context, executemany):
         # Don't record this query in the appmap.
         pass
     elif recorder.enabled:
-        Metadata.add_framework('SQLAlchemy', sqlalchemy.__version__)
+        Metadata.add_framework("SQLAlchemy", sqlalchemy.__version__)
         if executemany:
             # Sometimes the same query is executed with different parameter sets.
             # Instead of substituting them all, just say how many times it was run.
             try:
                 times = len(parameters)
             except TypeError:
-                times = '?'
-            sql = '-- %s times\n%s' % (times, statement)
+                times = "?"
+            sql = "-- %s times\n%s" % (times, statement)
         else:
             sql = statement
         dialect = conn.dialect
-        call_event = SqlEvent(sql, vendor=dialect.name, version=dialect.server_version_info)
+        call_event = SqlEvent(
+            sql, vendor=dialect.name, version=dialect.server_version_info
+        )
         Recorder.add_event(call_event)
         setattr(
-            context, 'appmap',
-            { 'start_time': time.monotonic(), 'call_event_id': call_event.id }
+            context,
+            "appmap",
+            {"start_time": time.monotonic(), "call_event_id": call_event.id},
         )
 
 
-@event.listens_for(Engine, 'after_cursor_execute')
+@event.listens_for(Engine, "after_cursor_execute")
 # pylint: disable=too-many-arguments,unused-argument
 def capture_sql(conn, cursor, statement, parameters, context, executemany):
     """Capture SQL query return into appmap."""
@@ -53,7 +57,9 @@ def capture_sql(conn, cursor, statement, parameters, context, executemany):
         pass
     elif recorder.enabled:
         stop = time.monotonic()
-        duration = stop - context.appmap['start_time']
-        return_event = ReturnEvent(parent_id=context.appmap['call_event_id'], elapsed=duration)
+        duration = stop - context.appmap["start_time"]
+        return_event = ReturnEvent(
+            parent_id=context.appmap["call_event_id"], elapsed=duration
+        )
         del context.appmap
         Recorder.add_event(return_event)

--- a/appmap/test/appmap_test_base.py
+++ b/appmap/test/appmap_test_base.py
@@ -1,8 +1,8 @@
-from operator import itemgetter
+import json
 import platform
 import re
+from operator import itemgetter
 
-import json
 import pytest
 
 import appmap._implementation
@@ -34,37 +34,35 @@ class AppMapTestBase:
 
     @staticmethod
     def normalize_git(git):
-        git.pop('repository')
-        git.pop('branch')
-        git.pop('commit')
-        status = git.pop('status')
+        git.pop("repository")
+        git.pop("branch")
+        git.pop("commit")
+        status = git.pop("status")
         assert isinstance(status, list)
-        tag = git.pop('tag', None)
+        tag = git.pop("tag", None)
         if tag:
             assert isinstance(tag, str)
-        commits_since_tag = git.pop('commits_since_tag', None)
+        commits_since_tag = git.pop("commits_since_tag", None)
         if commits_since_tag:
             assert isinstance(commits_since_tag, int)
-        git.pop('annotated_tag', None)
+        git.pop("annotated_tag", None)
 
-        commits_since_annotated_tag = git.pop(
-            'commits_since_annotated_tag', None
-        )
+        commits_since_annotated_tag = git.pop("commits_since_annotated_tag", None)
         if commits_since_annotated_tag:
             assert isinstance(commits_since_annotated_tag, int)
 
     @staticmethod
     def normalize_metadata(metadata):
-        engine = metadata['language'].pop('engine')
+        engine = metadata["language"].pop("engine")
         assert engine == platform.python_implementation()
-        version = metadata['language'].pop('version')
+        version = metadata["language"].pop("version")
         assert version == platform.python_version()
 
-        if 'frameworks' in metadata:
-            frameworks = metadata['frameworks']
+        if "frameworks" in metadata:
+            frameworks = metadata["frameworks"]
             for f in frameworks:
-                if f['name'] == 'pytest':
-                    v = f.pop('version')
+                if f["name"] == "pytest":
+                    v = f.pop("version")
                     assert v == pytest.__version__
 
     def normalize_appmap(self, generated_appmap):
@@ -77,33 +75,33 @@ class AppMapTestBase:
         """
 
         def normalize(dct):
-            if 'classMap' in dct:
-                dct['classMap'].sort(key=itemgetter('name'))
-            if 'children' in dct:
-                dct['children'].sort(key=itemgetter('name'))
-            if 'elapsed' in dct:
-                elapsed = dct.pop('elapsed')
+            if "classMap" in dct:
+                dct["classMap"].sort(key=itemgetter("name"))
+            if "children" in dct:
+                dct["children"].sort(key=itemgetter("name"))
+            if "elapsed" in dct:
+                elapsed = dct.pop("elapsed")
                 assert isinstance(elapsed, float)
-            if 'git' in dct:
-                self.normalize_git(dct.pop('git'))
-            if 'location' in dct:
-                dct['location'] = normalize_path(dct['location'])
-            if 'path' in dct:
-                dct['path'] = normalize_path(dct['path'])
-            if 'metadata' in dct:
-                self.normalize_metadata(dct['metadata'])
-            if 'object_id' in dct:
-                object_id = dct.pop('object_id')
+            if "git" in dct:
+                self.normalize_git(dct.pop("git"))
+            if "location" in dct:
+                dct["location"] = normalize_path(dct["location"])
+            if "path" in dct:
+                dct["path"] = normalize_path(dct["path"])
+            if "metadata" in dct:
+                self.normalize_metadata(dct["metadata"])
+            if "object_id" in dct:
+                object_id = dct.pop("object_id")
                 assert isinstance(object_id, int)
-            if 'value' in dct:
+            if "value" in dct:
                 # This maps all object references to the same
                 # location. We don't actually need to verify that the
                 # locations are correct -- if they weren't, the
                 # instrumented code would be broken, right?
-                v = dct['value']
-                dct['value'] = re.sub(r'<(.*) object at 0x.*>',
-                                      r'<\1 object at 0xabcdef>',
-                                      v)
+                v = dct["value"]
+                dct["value"] = re.sub(
+                    r"<(.*) object at 0x.*>", r"<\1 object at 0xabcdef>", v
+                )
             return dct
 
         return json.loads(generated_appmap, object_hook=normalize)

--- a/appmap/test/conftest.py
+++ b/appmap/test/conftest.py
@@ -1,5 +1,6 @@
-from distutils.dir_util import copy_tree
 import importlib
+from distutils.dir_util import copy_tree
+
 import pytest
 import yaml
 
@@ -8,17 +9,21 @@ from appmap._implementation import utils
 from appmap._implementation.env import Env
 from appmap._implementation.recording import Recorder
 
-def _data_dir(pytestconfig):
-    return pytestconfig.rootpath / 'appmap' / 'test' / 'data'
 
-@pytest.fixture(name='data_dir')
+def _data_dir(pytestconfig):
+    return pytestconfig.rootpath / "appmap" / "test" / "data"
+
+
+@pytest.fixture(name="data_dir")
 def fixture_data_dir(pytestconfig):
     return _data_dir(pytestconfig)
 
-@pytest.fixture(name='with_data_dir')
+
+@pytest.fixture(name="with_data_dir")
 def fixture_with_data_dir(data_dir, monkeypatch):
     monkeypatch.syspath_prepend(data_dir)
     return data_dir
+
 
 @pytest.fixture
 def events():
@@ -29,19 +34,20 @@ def events():
     rec.enabled = False
     rec.clear()
 
+
 @pytest.hookimpl
 def pytest_runtest_setup(item):
-    mark = item.get_closest_marker('appmap_enabled')
+    mark = item.get_closest_marker("appmap_enabled")
     env = {}
     if mark:
-        appmap_yml = mark.kwargs.get('config', 'appmap.yml')
+        appmap_yml = mark.kwargs.get("config", "appmap.yml")
         d = _data_dir(item.config)
         config = d / appmap_yml
-        Env.current.set('APPMAP_CONFIG', config)
-        appmap_enabled = mark.kwargs.get('appmap_enabled', 'true')
-        env = {'APPMAP_CONFIG': config}
+        Env.current.set("APPMAP_CONFIG", config)
+        appmap_enabled = mark.kwargs.get("appmap_enabled", "true")
+        env = {"APPMAP_CONFIG": config}
         if isinstance(appmap_enabled, str):
-            env['APPMAP'] = appmap_enabled
+            env["APPMAP"] = appmap_enabled
 
     appmap._implementation.initialize(env=env)  # pylint: disable=protected-access
 
@@ -49,23 +55,25 @@ def pytest_runtest_setup(item):
     # Reload it to make sure it's instrumented, or not, as set in appmap.yml.
     importlib.reload(yaml)
 
-@pytest.fixture(scope='session', name='git_directory')
+
+@pytest.fixture(scope="session", name="git_directory")
 def git_directory_fixture(tmp_path_factory):
-    git_dir = tmp_path_factory.mktemp('test_project')
-    (git_dir / 'README.metadata').write_text('Read me')
-    (git_dir / 'new_file').write_text('new_file')
+    git_dir = tmp_path_factory.mktemp("test_project")
+    (git_dir / "README.metadata").write_text("Read me")
+    (git_dir / "new_file").write_text("new_file")
 
     git = utils.git(cwd=git_dir)
-    git('init')
-    git('config --local user.email test@test')
-    git('config --local user.name Test')
-    git('add README.metadata')
+    git("init")
+    git("config --local user.email test@test")
+    git("config --local user.name Test")
+    git("add README.metadata")
     git('commit -m "initial commit"')
-    git('remote add origin https://www.example.test/repo.git')
+    git("remote add origin https://www.example.test/repo.git")
 
     return git_dir
 
-@pytest.fixture(name='git')
+
+@pytest.fixture(name="git")
 def tmp_git(git_directory, tmp_path):
     copy_tree(git_directory, str(tmp_path))
     return utils.git(cwd=tmp_path)

--- a/appmap/test/data/django/app/__init__.py
+++ b/appmap/test/data/django/app/__init__.py
@@ -3,15 +3,16 @@ from pathlib import Path
 import django
 import django.conf
 
-
 django.conf.settings.configure(
-    DATABASES={'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': ':memory:'}},
-    MIDDLEWARE=['django.middleware.http.ConditionalGetMiddleware'],
-    ROOT_URLCONF='app.urls',
-    TEMPLATES=[{
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [Path(__file__).parent],
-    }],
+    DATABASES={"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}},
+    MIDDLEWARE=["django.middleware.http.ConditionalGetMiddleware"],
+    ROOT_URLCONF="app.urls",
+    TEMPLATES=[
+        {
+            "BACKEND": "django.template.backends.django.DjangoTemplates",
+            "DIRS": [Path(__file__).parent],
+        }
+    ],
 )
 
 django.setup()

--- a/appmap/test/data/django/app/middleware.py
+++ b/appmap/test/data/django/app/middleware.py
@@ -1,7 +1,6 @@
 def hello_world(get_response):
-
     def _hello_world(request):
-        print('Hello world!')
+        print("Hello world!")
         return get_response(request)
 
     return _hello_world

--- a/appmap/test/data/django/app/urls.py
+++ b/appmap/test/data/django/app/urls.py
@@ -1,53 +1,73 @@
 import django.http
 from django.urls import include, path, re_path
 
+
 def view(_request):
-    return django.http.HttpResponse('testing')
+    return django.http.HttpResponse("testing")
+
 
 def user_view(_request, username):
-    return django.http.HttpResponse(f'user {username}')
+    return django.http.HttpResponse(f"user {username}")
+
 
 def post_view(_request, post_id):
-    return django.http.HttpResponse(f'post {post_id}')
+    return django.http.HttpResponse(f"post {post_id}")
+
 
 def post_unnamed_view(_request, arg):
-    return django.http.HttpResponse(f'post with unnamed, {arg}')
+    return django.http.HttpResponse(f"post with unnamed, {arg}")
+
 
 def user_post_view(_request, username, post_id):
-    return django.http.HttpResponse(f'post {username} {post_id}')
+    return django.http.HttpResponse(f"post {username} {post_id}")
+
 
 def echo_view(request):
     return django.http.HttpResponse(request.body)
 
+
 def exception_view(_request):
     raise RuntimeError("An error")
 
+
 def user_included_view(_request, username):
-    return django.http.HttpResponse(f'user {username}, included')
+    return django.http.HttpResponse(f"user {username}, included")
+
 
 def acl_edit(_request, pk):
-    return django.http.HttpResponse(f'acl_edit {pk}')
+    return django.http.HttpResponse(f"acl_edit {pk}")
+
 
 # replicate a problematic bit of misago's routing
 admincp_patterns = [
-    re_path('^', include([
-        re_path(r'^permissions/', include(([
-            re_path(r'^edit/(?P<pk>\d+)$', acl_edit, name='edit')
-        ], "permissions"), namespace="permissions"))
-    ]))
+    re_path(
+        "^",
+        include(
+            [
+                re_path(
+                    r"^permissions/",
+                    include(
+                        (
+                            [re_path(r"^edit/(?P<pk>\d+)$", acl_edit, name="edit")],
+                            "permissions",
+                        ),
+                        namespace="permissions",
+                    ),
+                )
+            ]
+        ),
+    )
 ]
 
 urlpatterns = [
-    path('test', view),
-    path('', view),
-    re_path('^user/(?P<username>[^/]+)$', user_view),
-    path('post/<int:post_id>', post_view),
-    path('post/<username>/<int:post_id>/summary', user_post_view),
-    re_path(r'^post/unnamed/(\d+)$', post_unnamed_view),
-    path('echo', echo_view),
-    path('exception', exception_view),
-    re_path(r'^post/included/', include([
-            path('<username>', user_view)])),
-
-    re_path(r'^admincp/', include((admincp_patterns, 'admin'), namespace="admin"))
+    path("test", view),
+    path("", view),
+    re_path("^user/(?P<username>[^/]+)$", user_view),
+    path("post/<int:post_id>", post_view),
+    path("post/<username>/<int:post_id>/summary", user_post_view),
+    re_path(r"^post/unnamed/(\d+)$", post_unnamed_view),
+    path("echo", echo_view),
+    path("exception", exception_view),
+    re_path(r"^post/included/", include([path("<username>", user_view)])),
+    re_path(r"^admincp/", include((admincp_patterns, "admin"), namespace="admin")),
 ]

--- a/appmap/test/data/django/test/test_app.py
+++ b/appmap/test/data/django/test/test_app.py
@@ -1,21 +1,18 @@
-from django.core.handlers.base import BaseHandler
-
 import app
-
+from django.core.handlers.base import BaseHandler
 from django.test import Client
 
+
 def test_middleware(rf, settings):
-    settings.MIDDLEWARE = [
-        "app.middleware.hello_world"
-    ]
-    request = rf.get('/')
+    settings.MIDDLEWARE = ["app.middleware.hello_world"]
+    request = rf.get("/")
     handler = BaseHandler()
     handler.load_middleware()
     response = handler.get_response(request)
     assert response.status_code == 200
 
+
 def test_app(settings):
-    response = Client().get('/')
+    response = Client().get("/")
 
     assert response.status_code == 200
-

--- a/appmap/test/data/example_class.py
+++ b/appmap/test/data/example_class.py
@@ -3,9 +3,8 @@ and called. Used for testing appmap instrumentation.
 """
 # pylint: disable=missing-function-docstring
 
-from functools import lru_cache, wraps
 import time
-
+from functools import lru_cache, wraps
 
 import appmap
 
@@ -13,7 +12,7 @@ import appmap
 class ClassMethodMixin:
     @classmethod
     def class_method(cls):
-        return 'ClassMethodMixin#class_method, cls %s' % (cls.__name__)
+        return "ClassMethodMixin#class_method, cls %s" % (cls.__name__)
 
 
 class Super:
@@ -21,24 +20,24 @@ class Super:
         return self.method_not_called_directly()
 
     def method_not_called_directly(self):
-        return 'Super#instance_method'
+        return "Super#instance_method"
 
 
 def wrap_fn(fn):
     @wraps(fn)
     def wrapped_fn(*args, **kwargs):
         try:
-            print('calling %s' % (fn.__name__))
+            print("calling %s" % (fn.__name__))
             return fn(*args, **kwargs)
         finally:
-            print('called %s' % (fn.__name__))
+            print("called %s" % (fn.__name__))
 
     return wrapped_fn
 
 
 class ExampleClass(Super, ClassMethodMixin):
     def __repr__(self):
-        return 'ExampleClass and %s' % (self.another_method())
+        return "ExampleClass and %s" % (self.another_method())
 
     # Include some lines so the line numbers in the expected appmap
     # don't change:
@@ -48,27 +47,27 @@ class ExampleClass(Super, ClassMethodMixin):
         return "ExampleClass#another_method"
 
     def test_exception(self):
-        raise Exception('test exception')
+        raise Exception("test exception")
 
     what_time_is_it = time.gmtime
 
-    @appmap.labels('super', 'important')
+    @appmap.labels("super", "important")
     def labeled_method(self):
-        return 'super important'
+        return "super important"
 
     @staticmethod
     @wrap_fn
     def wrapped_static_method():
-        return 'wrapped_static_method'
+        return "wrapped_static_method"
 
     @classmethod
     @wrap_fn
     def wrapped_class_method(cls):
-        return 'wrapped_class_method'
+        return "wrapped_class_method"
 
     @wrap_fn
     def wrapped_instance_method(self):
-        return 'wrapped_instance_method'
+        return "wrapped_instance_method"
 
     @staticmethod
     @lru_cache(maxsize=1)
@@ -80,12 +79,16 @@ class ExampleClass(Super, ClassMethodMixin):
 
     @staticmethod
     def static_method():
-        import yaml, io # Formatting is funky to minimize changes to expected appmap
-        yaml.Dumper(io.StringIO()).open(); return 'ExampleClass.static_method\n...\n'
+        import io
+
+        import yaml  # Formatting is funky to minimize changes to expected appmap
+
+        yaml.Dumper(io.StringIO()).open()
+        return "ExampleClass.static_method\n...\n"
 
     @staticmethod
     def call_yaml():
-        return ExampleClass.dump_yaml('ExampleClass.call_yaml')
+        return ExampleClass.dump_yaml("ExampleClass.call_yaml")
 
     @staticmethod
     def dump_yaml(data):
@@ -107,5 +110,6 @@ class ExampleClass(Super, ClassMethodMixin):
     def with_comment(self):
         return True
 
+
 def modfunc():
-    return 'Hello world!'
+    return "Hello world!"

--- a/appmap/test/data/flask/app.py
+++ b/appmap/test/data/flask/app.py
@@ -6,36 +6,36 @@ from markupsafe import escape
 
 from appmap.flask import AppmapFlask
 
-
 app = Flask(__name__)
 
 appmap_flask = AppmapFlask(app)
 
 
-@app.route('/')
+@app.route("/")
 def hello_world():
-    return 'Hello, World!'
+    return "Hello, World!"
 
 
-@app.route('/test')
+@app.route("/test")
 def the_test():
-    response = make_response('testing')
+    response = make_response("testing")
     response.add_etag()
     return response
 
 
-@app.route('/user/<username>')
+@app.route("/user/<username>")
 def show_user_profile(username):
     # show the user profile for that user
-    return 'User %s' % escape(username)
+    return "User %s" % escape(username)
 
 
-@app.route('/post/<int:post_id>')
+@app.route("/post/<int:post_id>")
 def show_post(post_id):
     # show the post with the given id, the id is an integer
-    return 'Post %d' % post_id
+    return "Post %d" % post_id
 
-@app.route('/post/<username>/<int:post_id>/summary')
+
+@app.route("/post/<username>/<int:post_id>/summary")
 def show_user_post(username, post_id):
     # Show the summary of a user's post
-    return f'User {escape(username)} post {post_id}'
+    return f"User {escape(username)} post {post_id}"

--- a/appmap/test/data/package1/package2/mod1.py
+++ b/appmap/test/data/package1/package2/mod1.py
@@ -1,3 +1,3 @@
 class Mod1Class:
     def func(self):
-        return 'Mod1Class.func'
+        return "Mod1Class.func"

--- a/appmap/test/data/params.py
+++ b/appmap/test/data/params.py
@@ -11,20 +11,21 @@ class C:
         return p
 
     def zero(self):
-        return 'Hello world!'
+        return "Hello world!"
 
     def one(self, p):
         return p
 
     def args_kwargs(self, *args, **kwargs):
-        return '%s %s' % (args, kwargs)
+        return "%s %s" % (args, kwargs)
 
     def with_defaults(self, p1=1, p2=2):
-        return '%s %s' % (p1, p2)
+        return "%s %s" % (p1, p2)
 
 
 if sys.version_info >= (3, 8):
-    exec("""
+    exec(
+        """
 def positional_only(self, p1, p2, /):
     return '%s %s' % (p1, p2)
 C.positional_only = positional_only
@@ -32,4 +33,5 @@ C.positional_only = positional_only
 def keyword_only(self, *, p1, p2):
     return '%s %s' % (p1, p2)
 C.keyword_only = keyword_only
-    """)
+    """
+    )

--- a/appmap/test/data/pytest/expected/pytest.appmap.json
+++ b/appmap/test/data/pytest/expected/pytest.appmap.json
@@ -13,7 +13,7 @@
       "name": "pytest"
     },
     "recording": {
-      "source_location": "test_simple.py:3"
+      "source_location": "test_simple.py:5"
     },
     "name": "hello world",
     "feature": "Hello world",
@@ -62,7 +62,6 @@
         "class": "builtins.str",
         "value": "'Hello'"
       },
-
       "thread_id": 1
     },
     {

--- a/appmap/test/data/pytest/simple.py
+++ b/appmap/test/data/pytest/simple.py
@@ -1,9 +1,9 @@
 class Simple:
     def hello(self):
-        return 'Hello'
+        return "Hello"
 
     def world(self):
-        return 'world!'
+        return "world!"
 
     def hello_world(self):
-        return '%s %s' % (self.hello(), self.world())
+        return "%s %s" % (self.hello(), self.world())

--- a/appmap/test/data/pytest/test_simple.py
+++ b/appmap/test/data/pytest/test_simple.py
@@ -1,10 +1,13 @@
 import os
+
 import pytest
+
 
 def test_hello_world():
     import simple
-    os.chdir('/tmp')
-    assert simple.Simple().hello_world() == 'Hello world!'
+
+    os.chdir("/tmp")
+    assert simple.Simple().hello_world() == "Hello world!"
 
 
 def test_status_failed():
@@ -22,4 +25,4 @@ def test_status_xsucceeded():
 
 
 def test_status_errored():
-    raise RuntimeError('test error')
+    raise RuntimeError("test error")

--- a/appmap/test/data/trial/expected/pytest.appmap.json
+++ b/appmap/test/data/trial/expected/pytest.appmap.json
@@ -12,7 +12,7 @@
     "recording": {
       "defined_class": "test.test_deferred.TestDeferred",
       "method_id": "test_hello_world",
-      "source_location": "test/test_deferred.py:8"
+      "source_location": "test/test_deferred.py:7"
     },
     "name": "Deferred hello world",
     "feature": "Hello world",
@@ -27,7 +27,7 @@
       "defined_class": "test.test_deferred.TestDeferred",
       "method_id": "test_hello_world",
       "path": "test/test_deferred.py",
-      "lineno": 9,
+      "lineno": 8,
       "static": false,
       "receiver": {
         "name": "self",
@@ -67,7 +67,7 @@
                 {
                   "name": "test_hello_world",
                   "type": "function",
-                  "location": "test/test_deferred.py:9",
+                  "location": "test/test_deferred.py:8",
                   "static": false
                 }
               ]

--- a/appmap/test/data/trial/test/test_deferred.py
+++ b/appmap/test/data/trial/test/test_deferred.py
@@ -1,11 +1,10 @@
 import time
 
-from twisted.internet import defer
-from twisted.internet import reactor
+from twisted.internet import defer, reactor
 from twisted.trial import unittest
 
-class TestDeferred(unittest.TestCase):
 
+class TestDeferred(unittest.TestCase):
     def test_hello_world(self):
         d = defer.Deferred()
 
@@ -17,4 +16,5 @@ class TestDeferred(unittest.TestCase):
         reactor.callLater(1, d.callback, None)
 
         return d
+
     test_hello_world.todo = "don't fix me"

--- a/appmap/test/data/unittest/simple/__init__.py
+++ b/appmap/test/data/unittest/simple/__init__.py
@@ -1,12 +1,12 @@
 class Simple:
     def hello(self):
-        return 'Hello'
+        return "Hello"
 
     def world(self):
-        return 'world'
+        return "world"
 
     def hello_world(self, bang):
-        return '%s %s%s' % (self.hello(), self.world(), bang)
+        return "%s %s%s" % (self.hello(), self.world(), bang)
 
     def getReady(self):
         pass

--- a/appmap/test/data/unittest/simple/test_simple.py
+++ b/appmap/test/data/unittest/simple/test_simple.py
@@ -1,23 +1,23 @@
 import unittest
 from unittest.mock import patch
 
+import simple
+
 # Importing from decouple will cause a failure if we're not hooking
 # finders correctly.
 from decouple import config
 
 import appmap.unittest
 
-import simple
-
 
 class UnitTestTest(unittest.TestCase):
     def test_hello_world(self):
-        self.assertEqual(simple.Simple().hello_world('!'), 'Hello world!')
+        self.assertEqual(simple.Simple().hello_world("!"), "Hello world!")
 
-    @patch('simple.Simple.hello_world')
+    @patch("simple.Simple.hello_world")
     def test_patch(self, patched_hw):
-        simple.Simple().hello_world('!')
-        patched_hw.assert_called_once_with('!')
+        simple.Simple().hello_world("!")
+        patched_hw.assert_called_once_with("!")
 
     def test_status_failed(self):
         self.assertTrue(False)
@@ -32,7 +32,7 @@ class UnitTestTest(unittest.TestCase):
 
     @staticmethod
     def test_status_errored():
-        raise RuntimeError('test error')
+        raise RuntimeError("test error")
 
     def setUp(self):
         simple.Simple().getReady()

--- a/appmap/test/helpers.py
+++ b/appmap/test/helpers.py
@@ -1,5 +1,6 @@
 """Test helpers"""
 
+
 class DictIncluding(dict):
     """A dict that on comparison just checks whether the other dict includes
     all of its items. Any extra ones are ignored.
@@ -11,5 +12,6 @@ class DictIncluding(dict):
 
     This is especially useful for tests.
     """
+
     def __eq__(self, other):
         return other.items() >= self.items()

--- a/appmap/test/normalize.py
+++ b/appmap/test/normalize.py
@@ -1,9 +1,9 @@
-from operator import itemgetter
+import json
 import platform
 import re
+from operator import itemgetter
 from typing import List
 
-import json
 import pytest
 
 
@@ -14,46 +14,48 @@ def normalize_path(path):
     """
     return re.sub(r"^.*site-packages/", "", path)
 
+
 def normalize_git(git):
-    git.pop('repository')
-    git.pop('branch')
-    git.pop('commit')
-    status = git.pop('status', [])
+    git.pop("repository")
+    git.pop("branch")
+    git.pop("commit")
+    status = git.pop("status", [])
     assert isinstance(status, list)
-    tag = git.pop('tag', None)
+    tag = git.pop("tag", None)
     if tag:
         assert isinstance(tag, str)
-    commits_since_tag = git.pop('commits_since_tag', None)
+    commits_since_tag = git.pop("commits_since_tag", None)
     if commits_since_tag:
         assert isinstance(commits_since_tag, int)
-    git.pop('annotated_tag', None)
+    git.pop("annotated_tag", None)
 
-    commits_since_annotated_tag = git.pop(
-        'commits_since_annotated_tag', None
-    )
+    commits_since_annotated_tag = git.pop("commits_since_annotated_tag", None)
     if commits_since_annotated_tag:
         assert isinstance(commits_since_annotated_tag, int)
 
+
 def normalize_metadata(metadata):
-    engine = metadata['language'].pop('engine')
+    engine = metadata["language"].pop("engine")
     assert engine == platform.python_implementation()
-    version = metadata['language'].pop('version')
+    version = metadata["language"].pop("version")
     assert version == platform.python_version()
 
-    if 'frameworks' in metadata:
-        frameworks = metadata['frameworks']
+    if "frameworks" in metadata:
+        frameworks = metadata["frameworks"]
         for f in frameworks:
-            if f['name'] == 'pytest':
-                v = f.pop('version')
+            if f["name"] == "pytest":
+                v = f.pop("version")
                 assert v == pytest.__version__
+
 
 def normalize_headers(dct):
     """Remove some headers which are variable between implementations.
     This allows sharing tests between web frameworks, for example.
     """
-    for hdr in ['User-Agent', 'Content-Length', 'ETag', 'Cookie', 'Host']:
+    for hdr in ["User-Agent", "Content-Length", "ETag", "Cookie", "Host"]:
         value = dct.pop(hdr, None)
         assert value is None or isinstance(value, str)
+
 
 def normalize_appmap(generated_appmap):
     """
@@ -62,46 +64,44 @@ def normalize_appmap(generated_appmap):
     """
 
     def normalize(dct):
-        if 'classMap' in dct:
-            dct['classMap'].sort(key=itemgetter('name'))
-        if 'children' in dct:
-            dct['children'].sort(key=itemgetter('name'))
-        if 'comment' in dct:
-            dct['comment'] = 'function comment'
-        if 'elapsed' in dct:
-            elapsed = dct.pop('elapsed')
+        if "classMap" in dct:
+            dct["classMap"].sort(key=itemgetter("name"))
+        if "children" in dct:
+            dct["children"].sort(key=itemgetter("name"))
+        if "comment" in dct:
+            dct["comment"] = "function comment"
+        if "elapsed" in dct:
+            elapsed = dct.pop("elapsed")
             assert isinstance(elapsed, float)
-        if 'frameworks' in dct:
-            assert all('name' in f for f in dct['frameworks'])
-            del dct['frameworks']
-        if 'git' in dct:
-            normalize_git(dct.pop('git'))
-        if 'headers' in dct:
-            normalize_headers(dct['headers'])
-            if len(dct['headers']) == 0:
-                del dct['headers']
-        if 'http_server_request' in dct:
-            normalize(dct['http_server_request'])
-            if 'message' in dct:
-                del dct['message']
-        if 'location' in dct:
-            dct['location'] = normalize_path(dct['location'])
-        if 'path' in dct:
-            dct['path'] = normalize_path(dct['path'])
-        if 'metadata' in dct:
-            normalize_metadata(dct['metadata'])
-        if 'object_id' in dct:
-            object_id = dct.pop('object_id')
+        if "frameworks" in dct:
+            assert all("name" in f for f in dct["frameworks"])
+            del dct["frameworks"]
+        if "git" in dct:
+            normalize_git(dct.pop("git"))
+        if "headers" in dct:
+            normalize_headers(dct["headers"])
+            if len(dct["headers"]) == 0:
+                del dct["headers"]
+        if "http_server_request" in dct:
+            normalize(dct["http_server_request"])
+            if "message" in dct:
+                del dct["message"]
+        if "location" in dct:
+            dct["location"] = normalize_path(dct["location"])
+        if "path" in dct:
+            dct["path"] = normalize_path(dct["path"])
+        if "metadata" in dct:
+            normalize_metadata(dct["metadata"])
+        if "object_id" in dct:
+            object_id = dct.pop("object_id")
             assert isinstance(object_id, int)
-        if 'value' in dct:
+        if "value" in dct:
             # This maps all object references to the same
             # location. We don't actually need to verify that the
             # locations are correct -- if they weren't, the
             # instrumented code would be broken, right?
-            v = dct['value']
-            dct['value'] = re.sub(r'<(.*)( object)* at 0x.*>',
-                                  r'<\1 at 0xabcdef>',
-                                  v)
+            v = dct["value"]
+            dct["value"] = re.sub(r"<(.*)( object)* at 0x.*>", r"<\1 at 0xabcdef>", v)
         return dct
 
     return json.loads(generated_appmap, object_hook=normalize)
@@ -113,14 +113,14 @@ def remove_line_numbers(appmap: dict):
     """
 
     def do_classmap(classmap: List[dict]):
-        location_re = re.compile(r':\d+$')
+        location_re = re.compile(r":\d+$")
         for entry in classmap:
-            if 'location' in entry:
-                entry['location'] = location_re.sub('', entry['location'])
-            do_classmap(entry.get('children', []))
+            if "location" in entry:
+                entry["location"] = location_re.sub("", entry["location"])
+            do_classmap(entry.get("children", []))
 
-    do_classmap(appmap['classMap'])
-    for event in appmap['events']:
-        assert isinstance(event.pop('lineno', 42), int)
+    do_classmap(appmap["classMap"])
+    for event in appmap["events"]:
+        assert isinstance(event.pop("lineno", 42), int)
 
     return appmap

--- a/appmap/test/test_command.py
+++ b/appmap/test/test_command.py
@@ -1,16 +1,17 @@
-from distutils.dir_util import copy_tree
-import os
 import json
-from pathlib import Path
+import os
 import re
+from distutils.dir_util import copy_tree
+from pathlib import Path
 
-
-from importlib_metadata import version
 import pytest
+from importlib_metadata import version
 
 import appmap._implementation
 from appmap.command import appmap_agent_init, appmap_agent_status, appmap_agent_validate
+
 from .helpers import DictIncluding
+
 
 @pytest.fixture
 def cmd_setup(request, git, data_dir, monkeypatch):
@@ -23,6 +24,7 @@ def cmd_setup(request, git, data_dir, monkeypatch):
 
     return monkeypatch
 
+
 @pytest.mark.parametrize("cmd_setup", ["config"], indirect=True)
 def test_agent_init(cmd_setup, capsys):
     rc = appmap_agent_init._run()
@@ -33,8 +35,9 @@ def test_agent_init(cmd_setup, capsys):
     # Make sure the JSON has the correct form, and contains the
     # expected filename. The contents of the default appmap.yml are
     # verified by other tests
-    assert config['configuration']['filename'] == 'appmap.yml'
-    assert config['configuration']['contents'] is not None
+    assert config["configuration"]["filename"] == "appmap.yml"
+    assert config["configuration"]["contents"] is not None
+
 
 class TestAgentStatus:
     @pytest.mark.parametrize("cmd_setup", ["pytest"], indirect=True)
@@ -46,7 +49,6 @@ class TestAgentStatus:
         call_count = 1 if do_discovery else 0
         assert appmap_agent_status.discover_pytest_tests.call_count == call_count
 
-
     @pytest.mark.parametrize("cmd_setup", ["pytest"], indirect=True)
     def test_agent_status(self, cmd_setup, capsys):
         rc = appmap_agent_status._run(discover_tests=True)
@@ -56,28 +58,27 @@ class TestAgentStatus:
         # XXX This will detect pytest as the test framework, because
         # appmap-python uses it. We need a better mechanism to handle
         # testing more broadly.
-        assert status == DictIncluding({
-            "properties": {
-                "config": {
-                    "app": "Simple",
-                    "present": True,
-                    "valid": True
+        assert status == DictIncluding(
+            {
+                "properties": {
+                    "config": {"app": "Simple", "present": True, "valid": True},
+                    "project": {
+                        "agentVersion": "0.0.0",
+                        "language": "python",
+                        "remoteRecordingCapable": True,
+                        "integrationTests": True,
+                    },
                 },
-            "project": {
-                "agentVersion": "0.0.0",
-                "language": "python",
-                "remoteRecordingCapable": True,
-                "integrationTests": True
+                "test_commands": [
+                    {
+                        "args": [],
+                        "framework": "pytest",
+                        "command": "pytest",
+                        "environment": {"APPMAP": "true"},
+                    }
+                ],
             }
-            },
-            "test_commands": [{
-                "args": [],
-                "framework": "pytest",
-                "command": "pytest",
-                "environment": {
-                    "APPMAP": "true"
-                }
-            }]})
+        )
 
     @pytest.mark.parametrize("cmd_setup", ["package1"], indirect=True)
     def test_agent_status(self, cmd_setup, capsys):
@@ -86,7 +87,8 @@ class TestAgentStatus:
         output = capsys.readouterr()
         status = json.loads(output.out)
 
-        assert 'test_commands' not in status
+        assert "test_commands" not in status
+
 
 class TestAgentValidate:
     def check_errors(self, capsys, status, count, msg):
@@ -99,31 +101,40 @@ class TestAgentValidate:
         assert len(errors) == count
         if count > 0:
             err = errors[0]
-            assert err['level'] == 'error'
-            assert re.match(msg , err['message']) != None
-
+            assert err["level"] == "error"
+            assert re.match(msg, err["message"]) != None
 
     def test_no_errors(self, capsys, mocker):
         # Both Django and flask are installed in a dev environment, so
         # validation will succeed.
         self.check_errors(capsys, 0, 0, None)
 
-
     def test_python_version(self, capsys, mocker):
-        mocker.patch('appmap._implementation.py_version_check._get_py_version', return_value=(3,5))
-        mocker.patch('appmap._implementation.py_version_check._get_platform_version', return_value='3.5')
+        mocker.patch(
+            "appmap._implementation.py_version_check._get_py_version",
+            return_value=(3, 5),
+        )
+        mocker.patch(
+            "appmap._implementation.py_version_check._get_platform_version",
+            return_value="3.5",
+        )
 
-        self.check_errors(capsys, 1, 1, r'Minimum Python version supported is \d\.\d, found')
+        self.check_errors(
+            capsys, 1, 1, r"Minimum Python version supported is \d\.\d, found"
+        )
 
     def test_django_version(self, capsys, mocker):
-        m = mocker.patch('appmap.command.appmap_agent_validate.version',
-                         side_effect=lambda d:  '3.1' if d == 'django' else version(d))
+        m = mocker.patch(
+            "appmap.command.appmap_agent_validate.version",
+            side_effect=lambda d: "3.1" if d == "django" else version(d),
+        )
 
-        self.check_errors(capsys, 1, 1, 'django must have version >= 3.2, found 3.1')
-
+        self.check_errors(capsys, 1, 1, "django must have version >= 3.2, found 3.1")
 
     def test_flask_version(self, capsys, mocker):
-        m = mocker.patch('appmap.command.appmap_agent_validate.version',
-                         side_effect=lambda d:  '1.0' if d == 'flask' else version(d))
+        m = mocker.patch(
+            "appmap.command.appmap_agent_validate.version",
+            side_effect=lambda d: "1.0" if d == "flask" else version(d),
+        )
 
-        self.check_errors(capsys, 1, 1,  'flask must have version >= 1.1, found 1.0')
+        self.check_errors(capsys, 1, 1, "flask must have version >= 1.1, found 1.0")

--- a/appmap/test/test_django.py
+++ b/appmap/test/test_django.py
@@ -2,6 +2,7 @@
 # pylint: disable=unused-import, redefined-outer-name, missing-function-docstring
 
 import json
+import sys
 from pathlib import Path
 
 import django
@@ -9,66 +10,65 @@ import django.conf
 import django.core.handlers.exception
 import django.db
 import django.http
-from django.template.loader import render_to_string
 import django.test
-from django.test.client import MULTIPART_CONTENT
-
 import pytest
+from django.template.loader import render_to_string
+from django.test.client import MULTIPART_CONTENT
 
 import appmap
 import appmap.django  # noqa: F401
 from appmap.test.helpers import DictIncluding
 
-import sys
-sys.path += [str(Path(__file__).parent / 'data' / 'django')]
+sys.path += [str(Path(__file__).parent / "data" / "django")]
 import app
+
 from .._implementation.metadata import Metadata
 
 # Make sure assertions in web_framework get rewritten (e.g. to show
 # diffs in generated appmaps)
-pytest.register_assert_rewrite('appmap.test.web_framework')
-from .web_framework import TestRequestCapture, TestRecording
+pytest.register_assert_rewrite("appmap.test.web_framework")
+from .web_framework import TestRecording, TestRequestCapture
+
 
 @pytest.mark.django_db
 def test_sql_capture(events):
-    conn = django.db.connections['default']
-    conn.cursor().execute('SELECT 1').fetchall()
-    assert events[0].sql_query == DictIncluding({
-        'sql': 'SELECT 1',
-        'database_type': 'sqlite'
-    })
-    assert events[0].sql_query['server_version'].startswith('3.')
-    assert Metadata()['frameworks'] == [{
-        'name': 'Django',
-        'version': django.get_version()
-    }]
+    conn = django.db.connections["default"]
+    conn.cursor().execute("SELECT 1").fetchall()
+    assert events[0].sql_query == DictIncluding(
+        {"sql": "SELECT 1", "database_type": "sqlite"}
+    )
+    assert events[0].sql_query["server_version"].startswith("3.")
+    assert Metadata()["frameworks"] == [
+        {"name": "Django", "version": django.get_version()}
+    ]
 
 
 @pytest.mark.appmap_enabled
 def test_framework_metadata(client, events):  # pylint: disable=unused-argument
-    client.get('/')
-    assert Metadata()['frameworks'] == [{
-        'name': 'Django',
-        'version': django.get_version()
-    }]
+    client.get("/")
+    assert Metadata()["frameworks"] == [
+        {"name": "Django", "version": django.get_version()}
+    ]
 
 
 @pytest.mark.appmap_enabled
 def test_app_can_read_body(client, events):  # pylint: disable=unused-argument
-    response = client.post('/echo', json={'test': 'json'})
+    response = client.post("/echo", json={"test": "json"})
     assert response.content == b'{"test": "json"}'
 
 
 @pytest.mark.appmap_enabled
 def test_template(events):
-    render_to_string('hello_world.html')
-    assert events[0].to_dict() == DictIncluding({
-        'path': 'appmap/test/data/django/app/hello_world.html',
-        'event': 'call',
-        'defined_class': '<templates>.AppmapTestDataDjangoAppHello_WorldHtml',
-        'method_id': 'render',
-        'static': False
-    })
+    render_to_string("hello_world.html")
+    assert events[0].to_dict() == DictIncluding(
+        {
+            "path": "appmap/test/data/django/app/hello_world.html",
+            "event": "call",
+            "defined_class": "<templates>.AppmapTestDataDjangoAppHello_WorldHtml",
+            "method_id": "render",
+            "static": False,
+        }
+    )
 
 
 # pylint: disable=arguments-differ
@@ -77,24 +77,32 @@ class ClientAdaptor(django.test.Client):
 
     # pylint: disable=too-many-arguments
     def generic(
-        self, method, path, data='', content_type='application/octet-stream', secure=False,
-        headers=None, json=None, **kwargs
+        self,
+        method,
+        path,
+        data="",
+        content_type="application/octet-stream",
+        secure=False,
+        headers=None,
+        json=None,
+        **kwargs
     ):
         headers = {
-            'HTTP_' + k.replace('-', '_').upper(): v
-            for k, v in (headers or {}).items()
+            "HTTP_" + k.replace("-", "_").upper(): v for k, v in (headers or {}).items()
         }
 
         if json:
-            content_type = 'application/json'
-            data = self._encode_json(json, 'application/json')
+            content_type = "application/json"
+            data = self._encode_json(json, "application/json")
 
-        return super().generic(method, path, data, content_type, secure, **headers, **kwargs)
+        return super().generic(
+            method, path, data, content_type, secure, **headers, **kwargs
+        )
 
-
-    def post(self, path, data=None, content_type=MULTIPART_CONTENT,
-             secure=False, **extra):
-        if content_type == 'multipart/form-data':
+    def post(
+        self, path, data=None, content_type=MULTIPART_CONTENT, secure=False, **extra
+    ):
+        if content_type == "multipart/form-data":
             content_type = MULTIPART_CONTENT
         return super().post(path, data, content_type, secure, **extra)
 
@@ -106,65 +114,71 @@ def client():
 
 @pytest.mark.appmap_enabled
 def test_unnamed(client, events):
-    client.get('/post/unnamed/5')
+    client.get("/post/unnamed/5")
 
-    assert appmap.enabled()     # sanity check
+    assert appmap.enabled()  # sanity check
     # unnamed captures in a re_path don't show up in the event's
     # message attribute.
     assert len(events[0].message) == 0
 
+
 @pytest.mark.appmap_enabled
 def test_included_view(client, events):
-    client.get('/post/included/test_user')
+    client.get("/post/included/test_user")
 
     assert len(events) == 2
-    assert events[0].http_server_request == DictIncluding({
-        'path_info': '/post/included/test_user',
-        'normalized_path_info': '/post/included/{username}'
-    })
+    assert events[0].http_server_request == DictIncluding(
+        {
+            "path_info": "/post/included/test_user",
+            "normalized_path_info": "/post/included/{username}",
+        }
+    )
+
 
 @pytest.mark.appmap_enabled
 def test_exception(client, events, monkeypatch):
     def raise_on_call(*args):
-        raise RuntimeError('An error')
-    monkeypatch.setattr(django.core.handlers.exception, 'response_for_exception', raise_on_call)
+        raise RuntimeError("An error")
+
+    monkeypatch.setattr(
+        django.core.handlers.exception, "response_for_exception", raise_on_call
+    )
 
     with pytest.raises(RuntimeError):
-        client.get('/exception')
+        client.get("/exception")
 
-    assert events[0].http_server_request == DictIncluding({
-        'request_method': 'GET',
-        'path_info': '/exception',
-        'protocol': 'HTTP/1.1'
-    })
+    assert events[0].http_server_request == DictIncluding(
+        {"request_method": "GET", "path_info": "/exception", "protocol": "HTTP/1.1"}
+    )
 
     assert events[1].parent_id == events[0].id
-    assert events[1].exceptions == [DictIncluding({
-            'class': 'builtins.RuntimeError',
-            'message': 'An error'
-    })]
+    assert events[1].exceptions == [
+        DictIncluding({"class": "builtins.RuntimeError", "message": "An error"})
+    ]
+
 
 @pytest.mark.appmap_enabled
 def test_deeply_nested_routes(client, events):
-    client.get('/admincp/permissions/edit/1')
+    client.get("/admincp/permissions/edit/1")
 
     assert len(events) == 2
-    assert events[0].http_server_request == DictIncluding({
-        'normalized_path_info': '/admincp/permissions/edit/{pk}'
-    })
+    assert events[0].http_server_request == DictIncluding(
+        {"normalized_path_info": "/admincp/permissions/edit/{pk}"}
+    )
+
 
 def test_middleware_reset(pytester, monkeypatch):
-    monkeypatch.setenv('PYTHONPATH', 'init')
-    monkeypatch.setenv('APPMAP', 'true')
+    monkeypatch.setenv("PYTHONPATH", "init")
+    monkeypatch.setenv("APPMAP", "true")
 
-    pytester.copy_example('django')
+    pytester.copy_example("django")
 
     # To really check middleware reset, the tests must run in order,
     # so disable randomly.
-    pytester.runpytest('-svv', '-p', 'no:randomly')
+    pytester.runpytest("-svv", "-p", "no:randomly")
 
     # Look for the http_server_request event in test_app's appmap. If
     # middleware reset is broken, it won't be there.
-    appmap_file = pytester.path / 'tmp' / 'appmap' / 'pytest' / 'test_app.appmap.json'
-    events = json.loads(appmap_file.read_text())['events']
-    assert 'http_server_request' in events[0]
+    appmap_file = pytester.path / "tmp" / "appmap" / "pytest" / "test_app.appmap.json"
+    events = json.loads(appmap_file.read_text())["events"]
+    assert "http_server_request" in events[0]

--- a/appmap/test/test_events.py
+++ b/appmap/test/test_events.py
@@ -1,22 +1,24 @@
 """
 Test event functionality
 """
+import re
 from functools import partial
 from queue import Queue
-import re
 from threading import Thread
 
 import pytest
 
 import appmap
 import appmap._implementation
-from appmap._implementation.event import _EventIds
 from appmap._implementation.env import Env
+from appmap._implementation.event import _EventIds
+
 
 # pylint: disable=import-error
 def test_per_thread_id():
-    """ thread ids should be constant for a  thread """
+    """thread ids should be constant for a  thread"""
     assert _EventIds.get_thread_id() == _EventIds.get_thread_id()
+
 
 def test_thread_ids():
     """thread ids should be different per thread"""
@@ -37,13 +39,15 @@ def test_thread_ids():
     all_tids = [tids.get() for _ in range(tids.qsize())]
     assert len(set(all_tids)) == len(all_tids)  # Should all be unique
 
+
 @pytest.mark.appmap_enabled
-@pytest.mark.usefixtures('with_data_dir')
+@pytest.mark.usefixtures("with_data_dir")
 class TestEvents:
     def test_recursion_protection(self):
         r = appmap.Recording()
         with r:
             from example_class import ExampleClass
+
             ExampleClass().instance_method()
 
         # If we get here, recursion protection for rendering the receiver
@@ -54,29 +58,31 @@ class TestEvents:
         r = appmap.Recording()
         with r:
             from example_class import ExampleClass
+
             param = mocker.Mock()
             param.__str__ = mocker.Mock(side_effect=Exception)
-            param.__repr__ = mocker.Mock(return_value='param.__repr__')
+            param.__repr__ = mocker.Mock(return_value="param.__repr__")
 
             ExampleClass().instance_with_param(param)
 
         assert len(r.events) > 0
-        expected_value = 'param.__repr__'
-        actual_value = r.events[0].parameters[0]['value']
+        expected_value = "param.__repr__"
+        actual_value = r.events[0].parameters[0]["value"]
         assert expected_value == actual_value
 
     def test_when_both_raise(self, mocker):
         r = appmap.Recording()
         with r:
             from example_class import ExampleClass
+
             param = mocker.Mock()
             param.__str__ = mocker.Mock(side_effect=Exception)
             param.__repr__ = mocker.Mock(side_effect=Exception)
 
             ExampleClass().instance_with_param(param)
 
-        expected_re = r'<.*? object at .*?>'
-        actual_value = r.events[0].parameters[0]['value']
+        expected_re = r"<.*? object at .*?>"
+        actual_value = r.events[0].parameters[0]["value"]
         assert re.fullmatch(expected_re, actual_value)
 
     def test_when_display_disabled(self, mocker):
@@ -84,6 +90,7 @@ class TestEvents:
         r = appmap.Recording()
         with r:
             from example_class import ExampleClass
+
             param = mocker.MagicMock()
 
             # unittest.mock.MagicMock doesn't mock __repr__ by default

--- a/appmap/test/test_flask.py
+++ b/appmap/test/test_flask.py
@@ -1,51 +1,55 @@
 """Test flask integration"""
 # pylint: disable=missing-function-docstring
 
-import flask
 import importlib
+
+import flask
 import pytest
 
 from appmap._implementation.env import Env
 from appmap.test.helpers import DictIncluding
+
 from .._implementation.metadata import Metadata
+from .web_framework import (  # pylint: disable=unused-import
+    TestRecording,
+    TestRequestCapture,
+)
 
-from .web_framework import TestRequestCapture, TestRecording  # pylint: disable=unused-import
 
-
-@pytest.fixture(name='client')
+@pytest.fixture(name="client")
 def flask_client(app):
     with app.test_client() as client:  # pylint: disable=no-member
         yield client
 
 
-@pytest.fixture(name='app')
+@pytest.fixture(name="app")
 def flask_app(data_dir, monkeypatch):
-    monkeypatch.syspath_prepend(data_dir / 'flask')
+    monkeypatch.syspath_prepend(data_dir / "flask")
 
-    Env.current.set("APPMAP_CONFIG", data_dir / 'flask' / 'appmap.yml')
+    Env.current.set("APPMAP_CONFIG", data_dir / "flask" / "appmap.yml")
 
     import app  # pylint: disable=import-error
+
     importlib.reload(app)
     return app.app
 
 
 @pytest.mark.appmap_enabled
 def test_framework_metadata(client, events):  # pylint: disable=unused-argument
-    client.get('/')
-    assert Metadata()['frameworks'] == [{
-        'name': 'flask',
-        'version': flask.__version__
-    }]
+    client.get("/")
+    assert Metadata()["frameworks"] == [{"name": "flask", "version": flask.__version__}]
 
 
 @pytest.mark.appmap_enabled
 def test_template(app, events):
     with app.app_context():
-        flask.render_template('test.html')
-    assert events[0].to_dict() == DictIncluding({
-        'path': 'appmap/test/data/flask/templates/test.html',
-        'event': 'call',
-        'defined_class': '<templates>.AppmapTestDataFlaskTemplatesTestHtml',
-        'method_id': 'render',
-        'static': False
-    })
+        flask.render_template("test.html")
+    assert events[0].to_dict() == DictIncluding(
+        {
+            "path": "appmap/test/data/flask/templates/test.html",
+            "event": "call",
+            "defined_class": "<templates>.AppmapTestDataFlaskTemplatesTestHtml",
+            "method_id": "render",
+            "static": False,
+        }
+    )

--- a/appmap/test/test_generation.py
+++ b/appmap/test/test_generation.py
@@ -5,64 +5,72 @@ import pytest
 import appmap
 from appmap._implementation import generation
 
-@pytest.fixture(name='verify_appmap')
+
+@pytest.fixture(name="verify_appmap")
 def fixture_verify_appmap(monkeypatch):
     def _generate(check_fn, method_name):
-        monkeypatch.setattr(generation.FuncEntry, 'to_dict',
-                            partialmethod(
-                                check_fn,
-                                generation.FuncEntry.to_dict))
+        monkeypatch.setattr(
+            generation.FuncEntry,
+            "to_dict",
+            partialmethod(check_fn, generation.FuncEntry.to_dict),
+        )
 
         from example_class import ExampleClass  # pylint: disable=import-error
+
         rec = appmap.Recording()
         with rec:
             m = getattr(ExampleClass(), method_name)
             m()
 
         return generation.dump(rec)
+
     return _generate
 
-@pytest.mark.appmap_enabled
-@pytest.mark.usefixtures('with_data_dir')
-class TestGeneration:
 
+@pytest.mark.appmap_enabled
+@pytest.mark.usefixtures("with_data_dir")
+class TestGeneration:
     def test_labeled(self, verify_appmap):
         def check_labels(self, to_dict):
-            if self.name == 'labeled_method':
-                assert list(self.labels) == ['super', 'important']
+            if self.name == "labeled_method":
+                assert list(self.labels) == ["super", "important"]
             ret = to_dict(self)
             return ret
-        verify_appmap(check_labels, 'labeled_method')
+
+        verify_appmap(check_labels, "labeled_method")
 
     def test_unlabeled(self, verify_appmap):
         def check_labels(self, to_dict):
-            if self.name == 'instance_method':
+            if self.name == "instance_method":
                 assert not self.labels
             ret = to_dict(self)
             return ret
-        verify_appmap(check_labels, 'instance_method')
+
+        verify_appmap(check_labels, "instance_method")
 
     def test_docstring(self, verify_appmap):
         def check_comment(self, to_dict):
-            if self.name == 'with_docstring':
-                assert self.comment == 'docstrings can have\nmultiple lines'
+            if self.name == "with_docstring":
+                assert self.comment == "docstrings can have\nmultiple lines"
             ret = to_dict(self)
             return ret
-        verify_appmap(check_comment, 'with_docstring')
+
+        verify_appmap(check_comment, "with_docstring")
 
     def test_comment(self, verify_appmap):
         def check_comment(self, to_dict):
-            if self.name == 'with_comment':
-                assert self.comment == '# comments can have\n# multiple lines\n'
+            if self.name == "with_comment":
+                assert self.comment == "# comments can have\n# multiple lines\n"
             ret = to_dict(self)
             return ret
-        verify_appmap(check_comment, 'with_comment')
 
+        verify_appmap(check_comment, "with_comment")
 
     def test_none(self, verify_appmap):
         def check_comment(self, to_dict):
-            if self.name == 'instance_method':
+            if self.name == "instance_method":
                 assert not self.comment
             ret = to_dict(self)
             return ret
-        verify_appmap(check_comment, 'instance_method')
+
+        verify_appmap(check_comment, "instance_method")

--- a/appmap/test/test_http.py
+++ b/appmap/test/test_http.py
@@ -7,29 +7,31 @@ import requests
 import appmap.http
 from appmap.test.helpers import DictIncluding
 
+
 def test_http_client_capture(mock_requests, events):
-    requests.get('https://example.test/foo/bar?q=one&q=two&q2=%F0%9F%A6%A0')
+    requests.get("https://example.test/foo/bar?q=one&q=two&q2=%F0%9F%A6%A0")
 
     request = events[0]
     assert request.http_client_request == {
-        'request_method': 'GET',
-        'url': 'https://example.test/foo/bar',
-        'headers': { 'Connection': 'keep-alive' },
+        "request_method": "GET",
+        "url": "https://example.test/foo/bar",
+        "headers": {"Connection": "keep-alive"},
     }
     message = request.message
-    assert message[0] == DictIncluding({ 'name': 'q', 'value': "['one', 'two']" })
-    assert (
-        (message[1] == DictIncluding({ 'name': 'q2', 'value': "'🦠'" }))
-        or (message[1] == DictIncluding({ 'name': 'q2', 'value': "'\\U0001f9a0'" }))
+    assert message[0] == DictIncluding({"name": "q", "value": "['one', 'two']"})
+    assert (message[1] == DictIncluding({"name": "q2", "value": "'🦠'"})) or (
+        message[1] == DictIncluding({"name": "q2", "value": "'\\U0001f9a0'"})
     )
 
-    assert events[1].http_client_response == DictIncluding({
-        'status_code': 200,
-        'mime_type': 'text/plain; charset=utf-8'
-    })
+    assert events[1].http_client_response == DictIncluding(
+        {"status_code": 200, "mime_type": "text/plain; charset=utf-8"}
+    )
 
-@pytest.fixture(name='mock_requests')
+
+@pytest.fixture(name="mock_requests")
 def mock_requests_fixture():
     with httpretty.enabled(allow_net_connect=False):
-        httpretty.register_uri(httpretty.GET, 'https://example.test/foo/bar', body='hello')
+        httpretty.register_uri(
+            httpretty.GET, "https://example.test/foo/bar", body="hello"
+        )
         yield

--- a/appmap/test/test_metadata.py
+++ b/appmap/test/test_metadata.py
@@ -4,67 +4,74 @@
 import pytest
 
 from appmap._implementation.metadata import Metadata
-
 from appmap.test.helpers import DictIncluding
 
 
 def test_missing_git(git, monkeypatch):
-    monkeypatch.setenv('PATH', '')
+    monkeypatch.setenv("PATH", "")
     try:
         metadata = Metadata(root_dir=git.cwd)
-        assert 'git' not in metadata
+        assert "git" not in metadata
     except FileNotFoundError:
         assert False, "_git_available didn't handle missing git"
 
 
 def test_git_metadata(git):
     metadata = Metadata(root_dir=git.cwd)
-    assert 'git' in metadata
-    git_md = metadata['git']
-    assert git_md == DictIncluding({
-        'repository': 'https://www.example.test/repo.git',
-        'branch': 'master',
-        'status': [
-            '?? new_file'
-        ]
-    })
+    assert "git" in metadata
+    git_md = metadata["git"]
+    assert git_md == DictIncluding(
+        {
+            "repository": "https://www.example.test/repo.git",
+            "branch": "master",
+            "status": ["?? new_file"],
+        }
+    )
     for key in (
-        'tag', 'annotated_tag', 'commits_since_tag', 'commits_since_annotated_tag'
+        "tag",
+        "annotated_tag",
+        "commits_since_tag",
+        "commits_since_annotated_tag",
     ):
         assert key not in git_md
 
 
 def test_tags(git):
-    atag = 'new_annotated_tag'
+    atag = "new_annotated_tag"
     git(f'tag -a "{atag}" -m "add annotated tag"')
 
-    git('add new_file')
+    git("add new_file")
     git('commit -m "added new file"')
 
-    tag = 'new_tag'
-    git(f'tag {tag}')
+    tag = "new_tag"
+    git(f"tag {tag}")
 
-    git('rm README.metadata')
+    git("rm README.metadata")
     git('commit -m "Removed readme"')
 
     metadata = Metadata(root_dir=git.cwd)
-    git_md = metadata['git']
+    git_md = metadata["git"]
 
-    assert git_md == DictIncluding({
-        'repository': 'https://www.example.test/repo.git',
-        'branch': 'master',
-        'tag': tag,
-        'annotated_tag': atag,
-        'commits_since_tag': 1,
-        'commits_since_annotated_tag': 2
-    })
+    assert git_md == DictIncluding(
+        {
+            "repository": "https://www.example.test/repo.git",
+            "branch": "master",
+            "tag": tag,
+            "annotated_tag": atag,
+            "commits_since_tag": 1,
+            "commits_since_annotated_tag": 2,
+        }
+    )
 
 
 def test_add_framework():
-    Metadata.add_framework('foo', '3.4')
-    Metadata.add_framework('foo', '3.4')
-    assert Metadata()['frameworks'] == [{'name': 'foo', 'version': '3.4'}]
+    Metadata.add_framework("foo", "3.4")
+    Metadata.add_framework("foo", "3.4")
+    assert Metadata()["frameworks"] == [{"name": "foo", "version": "3.4"}]
 
-    Metadata.add_framework('bar')
-    Metadata.add_framework('baz', '4.2')
-    assert Metadata()['frameworks'] == [{'name': 'bar'}, {'name': 'baz', 'version': '4.2'}]
+    Metadata.add_framework("bar")
+    Metadata.add_framework("baz", "4.2")
+    assert Metadata()["frameworks"] == [
+        {"name": "bar"},
+        {"name": "baz", "version": "4.2"},
+    ]

--- a/appmap/test/test_params.py
+++ b/appmap/test/test_params.py
@@ -6,23 +6,18 @@ import inspect
 import sys
 
 import pytest
-import vendor.wrapt.src.appmap.wrapt as wrapt
 
+import vendor.wrapt.src.appmap.wrapt as wrapt
 from appmap._implementation.event import CallEvent
 from appmap._implementation.recording import FilterableCls, FilterableFn
 
-empty_args = {
-    'name': 'args',
-    'class': 'builtins.tuple',
-    'kind': 'rest',
-    'value': '()'
-}
+empty_args = {"name": "args", "class": "builtins.tuple", "kind": "rest", "value": "()"}
 
 empty_kwargs = {
-    'name': 'kwargs',
-    'class': 'builtins.dict',
-    'kind': 'keyrest',
-    'value': '{}'
+    "name": "kwargs",
+    "class": "builtins.dict",
+    "kind": "keyrest",
+    "value": "{}",
 }
 
 
@@ -38,7 +33,9 @@ class _params:
 
         def wrapped_fn(_, instance, args, kwargs):
             return make_call_event(
-                parameters=CallEvent.set_params(params, instance, args, kwargs))
+                parameters=CallEvent.set_params(params, instance, args, kwargs)
+            )
+
         return wrapped_fn
 
     def wrap_test_func(self, fnname):
@@ -50,7 +47,8 @@ class _params:
         wrapped = self.prepare(ffn)
         wrapt.wrap_function_wrapper(C, fnname, wrapped)
 
-@pytest.mark.usefixtures('with_data_dir', autouse=True)
+
+@pytest.mark.usefixtures("with_data_dir", autouse=True)
 class TestMethodBase:
     @pytest.fixture
     def params(self, request):
@@ -60,21 +58,22 @@ class TestMethodBase:
         sees a pristine version of the classes it contains.
         """
         from params import C  # pylint: disable=import-error
+
         p = _params(C)
         p.wrap_test_func(request.param)
         yield p
-        del sys.modules['params']
+        del sys.modules["params"]
 
     def assert_receiver(self, evt, expected):
         r = evt.receiver
 
         # object_id is always present
-        r.pop('object_id')
+        r.pop("object_id")
 
         # value is always present, but we might not know what it
         # should be
-        if 'value' not in expected:
-            r.pop('value')
+        if "value" not in expected:
+            r.pop("value")
 
         assert r == expected
 
@@ -82,150 +81,161 @@ class TestMethodBase:
         parameter = evt.parameters[idx]
 
         # object_id is always present
-        parameter.pop('object_id')
+        parameter.pop("object_id")
 
         assert parameter == expected
 
 
 class TestStaticMethods(TestMethodBase):
-    @pytest.mark.parametrize('params', ['static'], indirect=True)
+    @pytest.mark.parametrize("params", ["static"], indirect=True)
     def test_no_receiver(self, params):
-        evt = params.C.static('param')
+        evt = params.C.static("param")
         assert not evt.receiver
 
-    @pytest.mark.parametrize('params', ['static'], indirect=True)
+    @pytest.mark.parametrize("params", ["static"], indirect=True)
     def test_one_param(self, params):
-        evt = params.C.static('static')
+        evt = params.C.static("static")
         assert len(evt.parameters) == 1
         parameter = evt.parameters[0]
 
-        parameter.pop('object_id')
+        parameter.pop("object_id")
 
         assert parameter == {
-            'name': 'p',
-            'class': 'builtins.str',
-            'kind': 'req',
-            'value': "'static'"
+            "name": "p",
+            "class": "builtins.str",
+            "kind": "req",
+            "value": "'static'",
         }
 
 
 class TestClassMethods(TestMethodBase):
-    @pytest.mark.parametrize('params', ['cls'], indirect=True)
+    @pytest.mark.parametrize("params", ["cls"], indirect=True)
     def test_one_param(self, params):
-        evt = params.C.cls('cls')
+        evt = params.C.cls("cls")
         assert len(evt.parameters) == 1
 
-        self.assert_receiver(evt, {
-            'name': 'cls',
-            'class': 'builtins.type',
-            'kind': 'req',
-            'value': "<class 'params.C'>"
-        })
+        self.assert_receiver(
+            evt,
+            {
+                "name": "cls",
+                "class": "builtins.type",
+                "kind": "req",
+                "value": "<class 'params.C'>",
+            },
+        )
 
-        self.assert_parameter(evt, 0, {
-            'name': 'p',
-            'class': 'builtins.str',
-            'kind': 'req',
-            'value': "'cls'"
-        })
+        self.assert_parameter(
+            evt,
+            0,
+            {"name": "p", "class": "builtins.str", "kind": "req", "value": "'cls'"},
+        )
 
 
 class TestInstanceMethods(TestMethodBase):
-    @pytest.mark.parametrize('params', ['zero'], indirect=True)
+    @pytest.mark.parametrize("params", ["zero"], indirect=True)
     def test_no_args(self, params):
         evt = params.C().zero()
         assert len(evt.parameters) == 0
-        self.assert_receiver(evt, {
-            'name': 'self',
-            'class': 'params.C',
-            'kind': 'req'
-        })
+        self.assert_receiver(evt, {"name": "self", "class": "params.C", "kind": "req"})
 
-    @pytest.mark.parametrize('params,arg,expected',
-                             [('one', 'world', ('builtins.str', "'world'")),
-                              ('one', None, ('builtins.NoneType', 'None'))],
-                             indirect=['params'])
+    @pytest.mark.parametrize(
+        "params,arg,expected",
+        [
+            ("one", "world", ("builtins.str", "'world'")),
+            ("one", None, ("builtins.NoneType", "None")),
+        ],
+        indirect=["params"],
+    )
     def test_one_param(self, params, arg, expected):
         evt = params.C().one(arg)
         assert len(evt.parameters) == 1
 
         expected_type, expected_value = expected
-        self.assert_parameter(evt, 0, {
-            'name': 'p',
-            'class': expected_type,
-            'kind': 'req',
-            'value': expected_value
-        })
+        self.assert_parameter(
+            evt,
+            0,
+            {
+                "name": "p",
+                "class": expected_type,
+                "kind": "req",
+                "value": expected_value,
+            },
+        )
 
     @staticmethod
-    @pytest.mark.parametrize('params', ['one'], indirect=True)
+    @pytest.mark.parametrize("params", ["one"], indirect=True)
     def test_one_arg_missing(params):
         evt = params.C().one()
         assert len(evt.parameters) == 0
 
-    @pytest.mark.parametrize('params', ['one'], indirect=True)
+    @pytest.mark.parametrize("params", ["one"], indirect=True)
     def test_one_receiver_none(self, params):
         evt = params.C.one(None, 1)
         assert len(evt.parameters) == 1
 
         assert evt.receiver == {
-            'name': 'self',
-            'kind': 'req',
-            'class': 'builtins.NoneType',
-            'object_id': evt.receiver['object_id'],
-            'value': 'None'
+            "name": "self",
+            "kind": "req",
+            "class": "builtins.NoneType",
+            "object_id": evt.receiver["object_id"],
+            "value": "None",
         }
 
-        self.assert_parameter(evt, 0, {
-            'name': 'p',
-            'class': 'builtins.int',
-            'kind': 'req',
-            'value': '1'
-        })
+        self.assert_parameter(
+            evt, 0, {"name": "p", "class": "builtins.int", "kind": "req", "value": "1"}
+        )
 
-    @pytest.mark.parametrize('params,arg,expected',
-                             [('one', 'world', ('builtins.str', "'world'")),
-                              ('one', None, ('builtins.NoneType', 'None'))],
-                             indirect=['params'])
+    @pytest.mark.parametrize(
+        "params,arg,expected",
+        [
+            ("one", "world", ("builtins.str", "'world'")),
+            ("one", None, ("builtins.NoneType", "None")),
+        ],
+        indirect=["params"],
+    )
     def test_one_param_kw(self, params, arg, expected):
         evt = params.C().one(p=arg)
         assert len(evt.parameters) == 1
 
         expected_type, expected_value = expected
-        self.assert_parameter(evt, 0, {
-            'name': 'p',
-            'class': expected_type,
-            'kind': 'req',
-            'value': expected_value
-        })
+        self.assert_parameter(
+            evt,
+            0,
+            {
+                "name": "p",
+                "class": expected_type,
+                "kind": "req",
+                "value": expected_value,
+            },
+        )
 
-    @pytest.mark.parametrize('params', ['args_kwargs'], indirect=True)
+    @pytest.mark.parametrize("params", ["args_kwargs"], indirect=True)
     def test_optional_no_args(self, params):
         evt = params.C().args_kwargs()
         assert len(evt.parameters) == 2
 
-        self.assert_receiver(evt, {
-            'name': 'self',
-            'class': 'params.C',
-            'kind': 'req'
-        })
+        self.assert_receiver(evt, {"name": "self", "class": "params.C", "kind": "req"})
 
         self.assert_parameter(evt, 0, empty_args)
         self.assert_parameter(evt, 1, empty_kwargs)
 
-    @pytest.mark.parametrize('params', ['args_kwargs'], indirect=True)
+    @pytest.mark.parametrize("params", ["args_kwargs"], indirect=True)
     def test_optional_2_positional(self, params):
         evt = params.C().args_kwargs(1, 2)
         assert len(evt.parameters) == 2
 
-        self.assert_parameter(evt, 0, {
-            'name': 'args',
-            'class': 'builtins.tuple',
-            'kind': 'rest',
-            'value': '(1, 2)'
-        })
+        self.assert_parameter(
+            evt,
+            0,
+            {
+                "name": "args",
+                "class": "builtins.tuple",
+                "kind": "rest",
+                "value": "(1, 2)",
+            },
+        )
 
-    @pytest.mark.parametrize('params', ['args_kwargs'], indirect=True)
+    @pytest.mark.parametrize("params", ["args_kwargs"], indirect=True)
     def test_optional_2_keyword(self, params):
         evt = params.C().args_kwargs(p1=1, p2=2)
         assert len(evt.parameters) == 2
@@ -233,92 +243,76 @@ class TestInstanceMethods(TestMethodBase):
         # pre 3.6, python doesn't preserve order of **kwargs. We don't
         # care about the order, though, so just check to make sure the
         # parameters have the correct values
-        value = evt.parameters[1].pop('value')
+        value = evt.parameters[1].pop("value")
         d = eval(value)  # pylint: disable=eval-used
-        assert d['p1'] == 1 and d['p2'] == 2
+        assert d["p1"] == 1 and d["p2"] == 2
 
-        self.assert_parameter(evt, 1, {
-            'name': 'kwargs',
-            'class': 'builtins.dict',
-            'kind': 'keyrest',
-        })
+        self.assert_parameter(
+            evt,
+            1,
+            {
+                "name": "kwargs",
+                "class": "builtins.dict",
+                "kind": "keyrest",
+            },
+        )
 
-    @pytest.mark.skipif(sys.version_info < (3, 8),
-                        reason='positional-only added in 3.8')
-    @pytest.mark.parametrize('params', ['positional_only'], indirect=True)
+    @pytest.mark.skipif(
+        sys.version_info < (3, 8), reason="positional-only added in 3.8"
+    )
+    @pytest.mark.parametrize("params", ["positional_only"], indirect=True)
     def test_positional_only(self, params):
         evt = params.C().positional_only(1, 2)
         assert len(evt.parameters) == 2
 
-        self.assert_parameter(evt, 0, {
-            'class': 'builtins.int',
-            'kind': 'req',
-            'name': 'p1',
-            'value': '1'
-        })
+        self.assert_parameter(
+            evt, 0, {"class": "builtins.int", "kind": "req", "name": "p1", "value": "1"}
+        )
 
-        self.assert_parameter(evt, 1, {
-            'class': 'builtins.int',
-            'kind': 'req',
-            'name': 'p2',
-            'value': '2'
-        })
+        self.assert_parameter(
+            evt, 1, {"class": "builtins.int", "kind": "req", "name": "p2", "value": "2"}
+        )
 
-    @pytest.mark.skipif(sys.version_info < (3, 8),
-                        reason='keyword-only added in 3.8')
-    @pytest.mark.parametrize('params', ['keyword_only'], indirect=True)
+    @pytest.mark.skipif(sys.version_info < (3, 8), reason="keyword-only added in 3.8")
+    @pytest.mark.parametrize("params", ["keyword_only"], indirect=True)
     def test_keyword_only(self, params):
         evt = params.C().keyword_only(p2=2, p1=1)
         assert len(evt.parameters) == 2
 
-        self.assert_parameter(evt, 0, {
-            'class': 'builtins.int',
-            'kind': 'keyreq',
-            'name': 'p1',
-            'value': '1'
-        })
+        self.assert_parameter(
+            evt,
+            0,
+            {"class": "builtins.int", "kind": "keyreq", "name": "p1", "value": "1"},
+        )
 
-        self.assert_parameter(evt, 1, {
-            'class': 'builtins.int',
-            'kind': 'keyreq',
-            'name': 'p2',
-            'value': '2'
-        })
+        self.assert_parameter(
+            evt,
+            1,
+            {"class": "builtins.int", "kind": "keyreq", "name": "p2", "value": "2"},
+        )
 
-    @pytest.mark.parametrize('params', ['with_defaults'], indirect=True)
+    @pytest.mark.parametrize("params", ["with_defaults"], indirect=True)
     def test_keywords_with_defaults(self, params):
         evt = params.C().with_defaults()
         assert len(evt.parameters) == 2
 
-        self.assert_parameter(evt, 0, {
-            'class': 'builtins.int',
-            'kind': 'opt',
-            'name': 'p1',
-            'value': '1'
-        })
+        self.assert_parameter(
+            evt, 0, {"class": "builtins.int", "kind": "opt", "name": "p1", "value": "1"}
+        )
 
-        self.assert_parameter(evt, 1, {
-            'class': 'builtins.int',
-            'kind': 'opt',
-            'name': 'p2',
-            'value': '2'
-        })
+        self.assert_parameter(
+            evt, 1, {"class": "builtins.int", "kind": "opt", "name": "p2", "value": "2"}
+        )
 
-    @pytest.mark.parametrize('params', ['with_defaults'], indirect=True)
+    @pytest.mark.parametrize("params", ["with_defaults"], indirect=True)
     def test_keywords_defaults_with_args(self, params):
         evt = params.C().with_defaults(p1=3, p2=4)
         assert len(evt.parameters) == 2
 
-        self.assert_parameter(evt, 0, {
-            'class': 'builtins.int',
-            'kind': 'opt',
-            'name': 'p1',
-            'value': '3'
-        })
+        self.assert_parameter(
+            evt, 0, {"class": "builtins.int", "kind": "opt", "name": "p1", "value": "3"}
+        )
 
-        self.assert_parameter(evt, 1, {
-            'class': 'builtins.int',
-            'kind': 'opt',
-            'name': 'p2',
-            'value': '4'
-        })
+        self.assert_parameter(
+            evt, 1, {"class": "builtins.int", "kind": "opt", "name": "p2", "value": "4"}
+        )

--- a/appmap/test/test_recording.py
+++ b/appmap/test/test_recording.py
@@ -5,8 +5,9 @@ import json
 import os
 import sys
 
-import appmap
 import pytest
+
+import appmap
 from appmap._implementation.event import Event
 from appmap._implementation.recording import Recorder, wrap_exec_module
 
@@ -22,9 +23,9 @@ class TestRecordingWhenEnabled:
 
         r = appmap.Recording()
         with r:
-            from example_class import (
+            from example_class import (  # pyright: ignore[reportMissingImports] pylint: disable=import-error
                 ExampleClass,
-            )  # pyright: ignore[reportMissingImports] pylint: disable=import-error
+            )
 
             ExampleClass.static_method()
             ExampleClass.class_method()
@@ -40,9 +41,9 @@ class TestRecordingWhenEnabled:
         assert remove_line_numbers(generated_appmap) == expected_appmap
 
     def test_recording_clears(self):
-        from example_class import (
+        from example_class import (  # pyright: ignore[reportMissingImports] pylint: disable=import-error
             ExampleClass,
-        )  # pyright: ignore[reportMissingImports] pylint: disable=import-error
+        )
 
         with appmap.Recording():
             ExampleClass.static_method()
@@ -61,9 +62,9 @@ class TestRecordingWhenEnabled:
         assert rec.events[2].method_id == "instance_method"
 
     def test_recording_shallow(self):
-        from example_class import (
+        from example_class import (  # pyright: ignore[reportMissingImports] pylint: disable=import-error
             ExampleClass,
-        )  # pyright: ignore[reportMissingImports] pylint: disable=import-error
+        )
 
         rec = appmap.Recording()
         with rec:
@@ -75,9 +76,9 @@ class TestRecordingWhenEnabled:
         assert len(rec.events) == 8
 
     def test_recording_wrapped(self):
-        from example_class import (
+        from example_class import (  # pyright: ignore[reportMissingImports] pylint: disable=import-error
             ExampleClass,
-        )  # pyright: ignore[reportMissingImports] pylint: disable=import-error
+        )
 
         rec = appmap.Recording()
         with rec:
@@ -100,10 +101,11 @@ class TestRecordingWhenEnabled:
     def test_can_deepcopy_function(self):
         from copy import deepcopy
 
-        from appmap.wrapt import FunctionWrapper
-        from example_class import (
+        from example_class import (  # pyright: ignore[reportMissingImports] pylint: disable=import-error
             modfunc,
-        )  # pyright: ignore[reportMissingImports] pylint: disable=import-error
+        )
+
+        from appmap.wrapt import FunctionWrapper
 
         rec = appmap.Recording()
         with rec:
@@ -143,9 +145,9 @@ def test_exec_module_protection(monkeypatch):
 @pytest.mark.appmap_enabled
 @pytest.mark.usefixtures("with_data_dir")
 def test_static_cached(events):
-    from example_class import (
+    from example_class import (  # pyright: ignore[reportMissingImports] pylint: disable=import-outside-toplevel
         ExampleClass,
-    )  # pyright: ignore[reportMissingImports] pylint: disable=import-outside-toplevel
+    )
 
     ExampleClass.static_cached(42)
     assert (

--- a/appmap/test/test_recording.py
+++ b/appmap/test/test_recording.py
@@ -5,24 +5,27 @@ import json
 import os
 import sys
 
-import pytest
-
 import appmap
-
+import pytest
+from appmap._implementation.event import Event
 from appmap._implementation.recording import Recorder, wrap_exec_module
+
 from .normalize import normalize_appmap, remove_line_numbers
 
 
 @pytest.mark.appmap_enabled
-@pytest.mark.usefixtures('with_data_dir')
+@pytest.mark.usefixtures("with_data_dir")
 class TestRecordingWhenEnabled:
     def test_recording_works(self, with_data_dir):
-        with open(os.path.join(with_data_dir, 'expected.appmap.json')) as f:
+        with open(os.path.join(with_data_dir, "expected.appmap.json")) as f:
             expected_appmap = json.load(f)
 
         r = appmap.Recording()
         with r:
-            from example_class import ExampleClass  # pylint: disable=import-error
+            from example_class import (
+                ExampleClass,
+            )  # pyright: ignore[reportMissingImports] pylint: disable=import-error
+
             ExampleClass.static_method()
             ExampleClass.class_method()
             ExampleClass().instance_method()
@@ -37,7 +40,9 @@ class TestRecordingWhenEnabled:
         assert remove_line_numbers(generated_appmap) == expected_appmap
 
     def test_recording_clears(self):
-        from example_class import ExampleClass  # pylint: disable=import-error
+        from example_class import (
+            ExampleClass,
+        )  # pyright: ignore[reportMissingImports] pylint: disable=import-error
 
         with appmap.Recording():
             ExampleClass.static_method()
@@ -47,16 +52,19 @@ class TestRecordingWhenEnabled:
         with rec:
             ExampleClass.class_method()
 
-        assert rec.events[0].method_id == 'class_method'
+        assert rec.events[0].method_id == "class_method"
 
         # but it can be added to
         with rec:
             ExampleClass().instance_method()
 
-        assert rec.events[2].method_id == 'instance_method'
+        assert rec.events[2].method_id == "instance_method"
 
     def test_recording_shallow(self):
-        from example_class import ExampleClass  # pylint: disable=import-error
+        from example_class import (
+            ExampleClass,
+        )  # pyright: ignore[reportMissingImports] pylint: disable=import-error
+
         rec = appmap.Recording()
         with rec:
             ExampleClass.class_method()
@@ -67,7 +75,10 @@ class TestRecordingWhenEnabled:
         assert len(rec.events) == 8
 
     def test_recording_wrapped(self):
-        from example_class import ExampleClass  # pylint: disable=import-error
+        from example_class import (
+            ExampleClass,
+        )  # pyright: ignore[reportMissingImports] pylint: disable=import-error
+
         rec = appmap.Recording()
         with rec:
             ExampleClass.wrapped_class_method()
@@ -77,27 +88,32 @@ class TestRecordingWhenEnabled:
         assert len(rec.events) == 6
 
         evt = rec.events[-2]
-        assert evt.event == 'call'
-        assert evt.method_id == 'wrapped_instance_method'
+        assert evt.event == "call"
+        assert evt.method_id == "wrapped_instance_method"
 
     def test_cant_start_twice(self):
         rec = appmap.Recording()
         rec.start()
         with pytest.raises(RuntimeError):
             rec.start()
-    
+
     def test_can_deepcopy_function(self):
-        from example_class import modfunc  # pylint: disable=import-error
         from copy import deepcopy
+
         from appmap.wrapt import FunctionWrapper
+        from example_class import (
+            modfunc,
+        )  # pyright: ignore[reportMissingImports] pylint: disable=import-error
+
         rec = appmap.Recording()
         with rec:
             f1 = deepcopy(modfunc)
             f1()
 
         evt = rec.events[-2]
-        assert evt.event == 'call'
-        assert evt.method_id == 'modfunc'
+        assert evt.event == "call"
+        assert evt.method_id == "modfunc"
+
 
 def test_exec_module_protection(monkeypatch):
     """
@@ -114,7 +130,8 @@ def test_exec_module_protection(monkeypatch):
 
     def do_import(*args, **kwargs):  # pylint: disable=unused-argument
         pass
-    monkeypatch.setattr(Recorder, 'do_import', do_import)
+
+    monkeypatch.setattr(Recorder, "do_import", do_import)
     f = exec_module
     for _ in range(sys.getrecursionlimit()):
         f = wrap_exec_module(f)
@@ -124,12 +141,47 @@ def test_exec_module_protection(monkeypatch):
 
 
 @pytest.mark.appmap_enabled
-@pytest.mark.usefixtures('with_data_dir')
+@pytest.mark.usefixtures("with_data_dir")
 def test_static_cached(events):
-    from example_class import ExampleClass  # pylint: disable=import-outside-toplevel
+    from example_class import (
+        ExampleClass,
+    )  # pyright: ignore[reportMissingImports] pylint: disable=import-outside-toplevel
+
     ExampleClass.static_cached(42)
-    assert events[0].parameters[0].items() >= {
-        'name': 'value',
-        'class': 'builtins.int',
-        'value': '42'
-    }.items()
+    assert (
+        events[0].parameters[0].items()
+        >= {"name": "value", "class": "builtins.int", "value": "42"}.items()
+    )
+
+
+class TestRecordingPerThread:
+    def test_default_thread(self):
+        rec = Recorder()
+        evt = Event({id: 1})
+        rec.add_event(evt)
+        actual = rec.events
+        assert len(actual) == 1
+
+    def test_explicit_thread(self):
+        rec_default = Recorder()
+        rec2 = Recorder(2)
+        rec3 = Recorder(3)
+        evt2 = Event({})
+        evt2.thread_id = 2
+        evt3 = Event({})
+        evt3.thread_id = 3
+
+        # Add them to the default recorder, since that's what the instrumented code does.
+        rec_default.add_event(evt2)
+        rec_default.add_event(evt3)
+
+        default_events = rec_default.events
+        assert len(default_events) == 2
+
+        rec2_events = rec2.events
+        assert len(rec2_events) == 1
+        assert rec2_events[0].thread_id == 2
+
+        rec3_events = rec3.events
+        assert len(rec3_events) == 1
+        assert rec3_events[0].thread_id == 3

--- a/appmap/test/test_sqlalchemy.py
+++ b/appmap/test/test_sqlalchemy.py
@@ -1,61 +1,70 @@
 """Tests for the SQLAlchemy integration."""
 
 import pytest
-
 import sqlalchemy
-from sqlalchemy import create_engine
-from sqlalchemy import Table, Column, Integer, String, MetaData, ForeignKey
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    create_engine,
+)
 
-from appmap.test.helpers import DictIncluding
-from .._implementation.metadata import Metadata
 import appmap.sqlalchemy  # pylint: disable=unused-import
+from appmap.test.helpers import DictIncluding
+
+from .._implementation.metadata import Metadata
 from .appmap_test_base import AppMapTestBase
 
 
 class TestSQLAlchemy(AppMapTestBase):
     @staticmethod
     def test_sql_capture(connection, events):
-        connection.execute('SELECT 1')
-        assert events[0].sql_query == DictIncluding({
-            'sql': 'SELECT 1',
-            'database_type': 'sqlite'
-        })
-        assert events[0].sql_query['server_version'].startswith('3.')
-        assert Metadata()['frameworks'] == [{
-            'name': 'SQLAlchemy',
-            'version': sqlalchemy.__version__
-        }]
-
+        connection.execute("SELECT 1")
+        assert events[0].sql_query == DictIncluding(
+            {"sql": "SELECT 1", "database_type": "sqlite"}
+        )
+        assert events[0].sql_query["server_version"].startswith("3.")
+        assert Metadata()["frameworks"] == [
+            {"name": "SQLAlchemy", "version": sqlalchemy.__version__}
+        ]
 
     @staticmethod
     # pylint: disable=unused-argument
     def test_capture_ddl(events, schema):
-        assert 'CREATE TABLE addresses' in events[-2].sql_query['sql']
-
+        assert "CREATE TABLE addresses" in events[-2].sql_query["sql"]
 
     # pylint: disable=unused-argument
     def test_capture_insert(self, connection, schema, events):
-        ins = self.users.insert().values(name='jack', fullname='Jack Jones')
+        ins = self.users.insert().values(name="jack", fullname="Jack Jones")
         connection.execute(ins)
-        assert events[-2].sql_query['sql'] == 'INSERT INTO users (name, fullname) VALUES (?, ?)'
-
+        assert (
+            events[-2].sql_query["sql"]
+            == "INSERT INTO users (name, fullname) VALUES (?, ?)"
+        )
 
     # pylint: disable=unused-argument
     def test_capture_insert_many(self, connection, schema, events):
-        connection.execute(self.addresses.insert(), [
-           {'user_id': 1, 'email_address' : 'jack@yahoo.com'},
-           {'user_id': 1, 'email_address' : 'jack@msn.com'},
-           {'user_id': 2, 'email_address' : 'www@www.org'},
-           {'user_id': 2, 'email_address' : 'wendy@aol.com'},
-        ])
-        assert events[-2].sql_query['sql'] == \
-            '-- 4 times\nINSERT INTO addresses (user_id, email_address) VALUES (?, ?)'
-
+        connection.execute(
+            self.addresses.insert(),
+            [
+                {"user_id": 1, "email_address": "jack@yahoo.com"},
+                {"user_id": 1, "email_address": "jack@msn.com"},
+                {"user_id": 2, "email_address": "www@www.org"},
+                {"user_id": 2, "email_address": "wendy@aol.com"},
+            ],
+        )
+        assert (
+            events[-2].sql_query["sql"]
+            == "-- 4 times\nINSERT INTO addresses (user_id, email_address) VALUES (?, ?)"
+        )
 
     @staticmethod
     @pytest.fixture
     def engine():
-        return create_engine('sqlite:///:memory:')
+        return create_engine("sqlite:///:memory:")
 
     @staticmethod
     @pytest.fixture
@@ -63,15 +72,19 @@ class TestSQLAlchemy(AppMapTestBase):
         return engine.connect()
 
     metadata = MetaData()
-    users = Table('users', metadata,
-        Column('id', Integer, primary_key=True),
-        Column('name', String),
-        Column('fullname', String),
+    users = Table(
+        "users",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("name", String),
+        Column("fullname", String),
     )
-    addresses = Table('addresses', metadata,
-        Column('id', Integer, primary_key=True),
-        Column('user_id', None, ForeignKey('users.id')),
-        Column('email_address', String, nullable=False)
+    addresses = Table(
+        "addresses",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("user_id", None, ForeignKey("users.id")),
+        Column("email_address", String, nullable=False),
     )
 
     @pytest.fixture

--- a/appmap/test/web_framework.py
+++ b/appmap/test/web_framework.py
@@ -2,212 +2,212 @@
 # pylint: disable=missing-function-docstring
 
 import json
-import pytest
 
+import pytest
 
 import appmap
 from appmap.test.helpers import DictIncluding
+
 from .normalize import normalize_appmap
+
 
 def content_type(res):
     # headers attribute is available in Flask, and in Django as of
     # 3.2. For Django 2.2, headers are accessed from the response
     # directly.
-    getter = res.headers.get if hasattr(res, 'headers') else res.get
-    return getter('Content-Type')
+    getter = res.headers.get if hasattr(res, "headers") else res.get
+    return getter("Content-Type")
+
 
 @pytest.mark.appmap_enabled
 class TestRequestCapture:
     """Common tests for HTTP server request and response capture."""
+
     @staticmethod
     def test_http_capture(client, events):
         """Test GET request and response capture."""
-        client.get('/test')
+        client.get("/test")
 
-        assert events[0].http_server_request == DictIncluding({
-            'request_method': 'GET',
-            'path_info': '/test',
-            'protocol': 'HTTP/1.1'
-        })
+        assert events[0].http_server_request == DictIncluding(
+            {"request_method": "GET", "path_info": "/test", "protocol": "HTTP/1.1"}
+        )
 
         response = events[1].http_server_response
-        assert response == DictIncluding({
-            'status_code': 200,
-            'mime_type': 'text/html; charset=utf-8'
-        })
+        assert response == DictIncluding(
+            {"status_code": 200, "mime_type": "text/html; charset=utf-8"}
+        )
 
-        assert 'ETag' in response['headers']
+        assert "ETag" in response["headers"]
 
     @staticmethod
     def test_http_capture_post(client, events):
         """Test POST request with JSON body capture."""
         client.post(
-            '/test', json={'my_param': 'example'}, headers={
-                'Authorization': 'token "test-token"',
-                'Accept': 'application/json',
-                'Accept-Language': 'pl'
+            "/test",
+            json={"my_param": "example"},
+            headers={
+                "Authorization": 'token "test-token"',
+                "Accept": "application/json",
+                "Accept-Language": "pl",
+            },
+        )
+
+        assert events[0].http_server_request == DictIncluding(
+            {
+                "request_method": "POST",
+                "path_info": "/test",
+                "protocol": "HTTP/1.1",
+                "authorization": 'token "test-token"',
+                "mime_type": "application/json",
             }
         )
 
-        assert events[0].http_server_request == DictIncluding({
-            'request_method': 'POST',
-            'path_info': '/test',
-            'protocol': 'HTTP/1.1',
-            'authorization': 'token "test-token"',
-            'mime_type': 'application/json',
-        })
-
-        assert events[0].http_server_request['headers'] == DictIncluding({
-            'Accept': 'application/json',
-            'Accept-Language': 'pl'
-        })
+        assert events[0].http_server_request["headers"] == DictIncluding(
+            {"Accept": "application/json", "Accept-Language": "pl"}
+        )
 
     @staticmethod
     def test_post(events, client):
-        client.post('/test', data=json.dumps({ 'my_param': 'example' }),
-            content_type='application/json; charset=UTF-8',
+        client.post(
+            "/test",
+            data=json.dumps({"my_param": "example"}),
+            content_type="application/json; charset=UTF-8",
             headers={
-                'Authorization': 'token "test-token"',
-                'Accept': 'application/json',
-                'Accept-Language': 'pl'
-            }
+                "Authorization": 'token "test-token"',
+                "Accept": "application/json",
+                "Accept-Language": "pl",
+            },
         )
 
         assert events[0].message == [
-            DictIncluding({
-                'name': 'my_param',
-                'class': 'builtins.str',
-                'value': "'example'"
-            })
+            DictIncluding(
+                {"name": "my_param", "class": "builtins.str", "value": "'example'"}
+            )
         ]
-        assert events[0].http_server_request == DictIncluding({
-            'request_method': 'POST',
-            'path_info': '/test',
-            'protocol': 'HTTP/1.1',
-            'authorization': 'token "test-token"',
-            'mime_type': 'application/json; charset=UTF-8',
-        })
+        assert events[0].http_server_request == DictIncluding(
+            {
+                "request_method": "POST",
+                "path_info": "/test",
+                "protocol": "HTTP/1.1",
+                "authorization": 'token "test-token"',
+                "mime_type": "application/json; charset=UTF-8",
+            }
+        )
 
-        assert events[0].http_server_request['headers'] == DictIncluding({
-            'Accept': 'application/json',
-            'Accept-Language': 'pl'
-        })
+        assert events[0].http_server_request["headers"] == DictIncluding(
+            {"Accept": "application/json", "Accept-Language": "pl"}
+        )
 
     @staticmethod
     def test_get(events, client):
-        client.get('/test?my_param=example')
+        client.get("/test?my_param=example")
 
         assert events[0].message == [
-            DictIncluding({
-                'name': 'my_param',
-                'class': 'builtins.str',
-                'value': "'example'"
-            })
+            DictIncluding(
+                {"name": "my_param", "class": "builtins.str", "value": "'example'"}
+            )
         ]
 
     @staticmethod
     def test_get_arr(events, client):
-        client.get('/test?my_param=example&my_param=example2')
+        client.get("/test?my_param=example&my_param=example2")
 
         assert events[0].message == [
-            DictIncluding({
-                'name': 'my_param',
-                'class': 'builtins.list',
-                'value': "['example', 'example2']"
-            }),
+            DictIncluding(
+                {
+                    "name": "my_param",
+                    "class": "builtins.list",
+                    "value": "['example', 'example2']",
+                }
+            ),
         ]
-
 
     @staticmethod
     def test_post_form_urlencoded(events, client):
         client.post(
-            '/test', data='my_param=example',
-            content_type='application/x-www-form-urlencoded'
+            "/test",
+            data="my_param=example",
+            content_type="application/x-www-form-urlencoded",
         )
 
         assert events[0].message == [
-            DictIncluding({
-                'name': 'my_param',
-                'class': 'builtins.str',
-                'value': "'example'"
-            })
+            DictIncluding(
+                {"name": "my_param", "class": "builtins.str", "value": "'example'"}
+            )
         ]
 
     @staticmethod
     def test_put(events, client):
-        client.put('/test', json={ 'my_param': 'example' })
+        client.put("/test", json={"my_param": "example"})
 
         assert events[0].message == [
-            DictIncluding({
-                'name': 'my_param',
-                'class': 'builtins.str',
-                'value': "'example'"
-            })
+            DictIncluding(
+                {"name": "my_param", "class": "builtins.str", "value": "'example'"}
+            )
         ]
 
     @staticmethod
     def test_post_bad_json(events, client):
-        client.post('/test?my_param=example', data="bad json", content_type='application/json')
+        client.post(
+            "/test?my_param=example", data="bad json", content_type="application/json"
+        )
 
         assert events[0].message == [
-            DictIncluding({
-                'name': 'my_param',
-                'class': 'builtins.str',
-                'value': "'example'"
-            })
+            DictIncluding(
+                {"name": "my_param", "class": "builtins.str", "value": "'example'"}
+            )
         ]
 
     @staticmethod
     def test_post_multipart(events, client):
-        client.post('/test', data={ 'my_param': 'example' }, content_type='multipart/form-data')
+        client.post(
+            "/test", data={"my_param": "example"}, content_type="multipart/form-data"
+        )
 
         assert events[0].message == [
-            DictIncluding({
-                'name': 'my_param',
-                'class': 'builtins.str',
-                'value': "'example'"
-            })
+            DictIncluding(
+                {"name": "my_param", "class": "builtins.str", "value": "'example'"}
+            )
         ]
 
     @staticmethod
     def test_post_with_query(events, client):
-        client.post('/test?my_param=get', data={ 'my_param': 'example' })
+        client.post("/test?my_param=get", data={"my_param": "example"})
 
         assert events[0].message == [
-            DictIncluding({
-                'name': 'my_param',
-                'class': 'builtins.list',
-                'value': "['get', 'example']"
-            })
+            DictIncluding(
+                {
+                    "name": "my_param",
+                    "class": "builtins.list",
+                    "value": "['get', 'example']",
+                }
+            )
         ]
 
     @staticmethod
-    @pytest.mark.parametrize('url,expected', [
-        ('/user/test_user', '/user/{username}'),
-        ('/post/123', '/post/{post_id}'),
-        ('/post/test_user/123/summary', '/post/{username}/{post_id}/summary')
-    ])
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            ("/user/test_user", "/user/{username}"),
+            ("/post/123", "/post/{post_id}"),
+            ("/post/test_user/123/summary", "/post/{username}/{post_id}/summary"),
+        ],
+    )
     def test_path_normalization(client, events, url, expected):
         client.get(url)
-        np = events[0].http_server_request['normalized_path_info']
+        np = events[0].http_server_request["normalized_path_info"]
         assert np == expected
 
     @staticmethod
     @pytest.mark.appmap_enabled
     def test_message_path_segments(events, client):
-        client.get('/post/alice/42/summary')
+        client.get("/post/alice/42/summary")
 
         assert events[0].message == [
-            DictIncluding({
-                'name': 'username',
-                'class': 'builtins.str',
-                'value': "'alice'"
-            }),
-            DictIncluding({
-                'name': 'post_id',
-                'class': 'builtins.int',
-                'value': "42"
-            })
+            DictIncluding(
+                {"name": "username", "class": "builtins.str", "value": "'alice'"}
+            ),
+            DictIncluding({"name": "post_id", "class": "builtins.int", "value": "42"}),
         ]
 
 
@@ -218,58 +218,58 @@ class TestRecording:
     def test_appmap_disabled(client):
         assert not appmap.enabled()
 
-        res = client.get('/_appmap/record')
+        res = client.get("/_appmap/record")
         assert res.status_code == 404
 
     @staticmethod
     @pytest.mark.appmap_enabled
     def test_starts_disabled(client):
-        res = client.get('/_appmap/record')
+        res = client.get("/_appmap/record")
         assert res.status_code == 200
 
-        assert content_type(res) == 'application/json'
+        assert content_type(res) == "application/json"
 
         data = res.json
         if callable(data):
             data = data()
-        assert data == {'enabled': False}
+        assert data == {"enabled": False}
 
     @staticmethod
     @pytest.mark.appmap_enabled
     def test_can_be_enabled(client):
-        res = client.post('/_appmap/record')
+        res = client.post("/_appmap/record")
         assert res.status_code == 200
 
     @staticmethod
     @pytest.mark.appmap_enabled
     def test_can_only_enable_once(client):
-        res = client.post('/_appmap/record')
+        res = client.post("/_appmap/record")
         assert res.status_code == 200
-        res = client.post('/_appmap/record')
+        res = client.post("/_appmap/record")
         assert res.status_code == 409
 
     @staticmethod
     @pytest.mark.appmap_enabled
     def test_can_record(data_dir, client):
-        res = client.post('/_appmap/record')
+        res = client.post("/_appmap/record")
         assert res.status_code == 200
 
-        res = client.get('/')
+        res = client.get("/")
         assert res.status_code == 200
 
-        res = client.get('/user/test_user')
+        res = client.get("/user/test_user")
         assert res.status_code == 200
 
-        res = client.delete('/_appmap/record')
+        res = client.delete("/_appmap/record")
         assert res.status_code == 200
-        assert content_type(res) == 'application/json'
-        data = res.data if hasattr(res, 'data') else res.content
+        assert content_type(res) == "application/json"
+        data = res.data if hasattr(res, "data") else res.content
         generated_appmap = normalize_appmap(data)
 
-        with open(data_dir / 'remote.appmap.json') as expected:
+        with open(data_dir / "remote.appmap.json") as expected:
             expected_appmap = json.load(expected)
 
         assert generated_appmap == expected_appmap
 
-        res = client.delete('/_appmap/record')
+        res = client.delete("/_appmap/record")
         assert res.status_code == 404

--- a/appmap/unittest.py
+++ b/appmap/unittest.py
@@ -1,13 +1,13 @@
-from contextlib import contextmanager
 import logging
 import unittest
+from contextlib import contextmanager
 
 import appmap
-from appmap._implementation import testing_framework
 import appmap.wrapt as wrapt
-
+from appmap._implementation import testing_framework
 
 logger = logging.getLogger(__name__)
+
 
 def setup_unittest():
     if not appmap.enabled():
@@ -16,41 +16,43 @@ def setup_unittest():
         logger.warning("AppMap disabled. Did you forget to set APPMAP=true?")
         return
 
-    session = testing_framework.session('unittest')
+    session = testing_framework.session("unittest")
 
     def get_test_location(cls, method_name):
         from appmap._implementation.utils import get_function_location
+
         fn = getattr(cls, method_name)
         return get_function_location(fn)
-
 
     # unittest.case._Outcome.testPartExecutor is used by all supported
     # versions of unittest to run test cases. `isTest` will be True when
     # the part is the actual test method, False when it's setUp or
     # teardown.
-    @wrapt.patch_function_wrapper('unittest.case', '_Outcome.testPartExecutor')
+    @wrapt.patch_function_wrapper("unittest.case", "_Outcome.testPartExecutor")
     @contextmanager
     def testPartExecutor(wrapped, _, args, kwargs):
         def _args(test_case, *_, isTest=False, **__):
             return (test_case, isTest)
+
         test_case, is_test = _args(*args, **kwargs)
-        already_recording = getattr(test_case, '_appmap_pytest_recording', None)
+        already_recording = getattr(test_case, "_appmap_pytest_recording", None)
         if (not is_test) or already_recording:
             with wrapped(*args, **kwargs):
                 yield
             return
 
-        method_name = test_case.id().split('.')[-1]
+        method_name = test_case.id().split(".")[-1]
         location = get_test_location(test_case.__class__, method_name)
         with session.record(
-                test_case.__class__,
-                method_name,
-                location=location) as metadata:
-            with wrapped(*args, **kwargs), testing_framework.collect_result_metadata(metadata):
+            test_case.__class__, method_name, location=location
+        ) as metadata:
+            with wrapped(*args, **kwargs), testing_framework.collect_result_metadata(
+                metadata
+            ):
                 yield
 
 
 setup_unittest()
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main(module=None)

--- a/conftest.py
+++ b/conftest.py
@@ -3,5 +3,5 @@ import sys
 
 import pytest
 
-collect_ignore = [os.path.join('appmap', 'test', 'data')]
-pytest_plugins = ['pytester']
+collect_ignore = [os.path.join("appmap", "test", "data")]
+pytest_plugins = ["pytester"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,10 @@ Twisted = "^21.2.0"
 requests = "^2.25.1"
 python-decouple = "^3.5"
 
+[tool.poetry.group.dev.dependencies]
+black = "^22.8.0"
+isort = "^5.10.1"
+
 [build-system]
 requires = ["poetry-core>=1.1.0"]
 build-backend = "poetry.core.masonry.api"
@@ -79,3 +83,10 @@ appmap = "appmap.pytest"
 appmap-agent-init = "appmap.command.appmap_agent_init:run"
 appmap-agent-status = "appmap.command.appmap_agent_status:run"
 appmap-agent-validate = "appmap.command.appmap_agent_validate:run"
+
+[tool.black]
+extend-exclude = "vendor"
+
+[tool.isort]
+profile = "black"
+extend_skip = "vendor"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ packaging = "^21.3"
 # 
 # So, if you'd like to run the tests outside of tox,
 # you'll need to `pip install` the appropriate version of Django, e.g.
-#   pip install django '~=3.2'
+#   pip install django'>=3.2,<4.0'
 #   pip install pytest-django
 
 [tool.poetry.dev-dependencies]
@@ -60,6 +60,9 @@ coverage = "^5.3"
 pytest-mock = "^3.5.1"
 flask = "^1.1.2"
 MarkupSafe = "2.0.1"
+jinja2 = ">=2.10.1,<3"
+itsdangerous = ">=0.24,<2"
+Werkzeug = ">=0.15,<2"
 SQLAlchemy = { version = "^1.4.11", python = "^3.7"}
 tox = "^3.22.0"
 tox-pyenv = "^1.1.0"


### PR DESCRIPTION
When creating a Recorder, allow the caller to specify a thread id. When
new events are added, they will be separated based on the thread id in
the event itself.

The `refactor` touches a lot of files, but it's just the result of running `black` and `isort` on the source. It probably doesn't need much (or any) review.

Fixes getappmap/board#169.