### PR TITLE
feat: Create appmap.yml if it doesn't exist

### DIFF
--- a/appmap/_implementation/configuration.py
+++ b/appmap/_implementation/configuration.py
@@ -184,12 +184,13 @@ class Config:
 
         # Only use a default config if the user hasn't specified a
         # config.
-        env_config = Env.current.get("APPMAP_CONFIG")
-        use_default_config = not env_config
-        if use_default_config:
-            env_config = "appmap.yml"
+        env_config_filename = Env.current.get("APPMAP_CONFIG")
 
-        path = Path(env_config).resolve()
+        use_default_config = not env_config_filename
+        if use_default_config:
+            env_config_filename = "appmap.yml"
+
+        path = Path(env_config_filename).resolve()
         if path.is_file():
             self.file_present = True
 
@@ -213,17 +214,25 @@ class Config:
             logger.warning(
                 dedent(
                     f"""
-This default configuration will be used:
+It will be created with this configuration: 
 
 {yaml.dump(self.default)}
             """
                 )
             )
             self._config = self.default
+            self.write_config_file(path, self.default)
         else:
             # disable appmap and return a dummy config
             # so the errors don't accumulate
             Env.current.enabled = False
+
+    def write_config_file(self, filepath, config):
+        basedir = filepath.parent
+        if not basedir.exists():
+            basedir.mkdir(parents=True, exist_ok=True)
+        with open(filepath, "w") as f:
+            f.write(yaml.dump(config, sort_keys=True))
 
 
 def startswith(prefix, sequence):

--- a/appmap/test/test_configuration.py
+++ b/appmap/test/test_configuration.py
@@ -184,3 +184,31 @@ class TestDefaultConfig:
         # pylint: disable=protected-access
         appmap._implementation.initialize(cwd=tmpdir, env={"APPMAP": "true"})
         self.check_default_config(Path(tmpdir).name)
+
+    def test_created_if_missing_and_enabled(self, git, data_dir, monkeypatch):
+        repo_root = git.cwd
+        copy_tree(data_dir / "config", str(repo_root))
+        monkeypatch.chdir(repo_root)
+
+        path = Path(repo_root / "appmap.yml")
+        assert not path.is_file()
+
+        # pylint: disable=protected-access
+        appmap._implementation.initialize(cwd=repo_root, env={"APPMAP": "true"})
+
+        c = Config()
+        assert path.is_file()
+
+    def test_not_created_if_missing_and_not_enabled(self, git, data_dir, monkeypatch):
+        repo_root = git.cwd
+        copy_tree(data_dir / "config", str(repo_root))
+        monkeypatch.chdir(repo_root)
+
+        path = Path(repo_root / "appmap.yml")
+        assert not path.is_file()
+
+        # pylint: disable=protected-access
+        appmap._implementation.initialize(cwd=repo_root, env={"APPMAP": "false"})
+
+        c = Config()
+        assert not path.is_file()


### PR DESCRIPTION
Create `appmap.yml` if it doesn't exist, and don't create if appmap is disabled.

Fixes https://github.com/getappmap/appmap-python/issues/169