### PR TITLE
feat: Update appmap format from 1.4 to 1.9.0

### DIFF
--- a/appmap/_implementation/event.py
+++ b/appmap/_implementation/event.py
@@ -72,11 +72,14 @@ def display_string(val):
 
 
 def describe_value(val):
-    return {
+    ret = {
         "class": fqname(type(val)),
         "object_id": id(val),
         "value": display_string(val),
     }
+    if isinstance(val, list) or isinstance(val, dict):
+        ret["size"] = len(val)
+    return ret
 
 
 class Event:

--- a/appmap/_implementation/generation.py
+++ b/appmap/_implementation/generation.py
@@ -95,7 +95,7 @@ def appmap(recording, metadata):
         appmap_metadata.update(metadata)
 
     return {
-        "version": "1.4",
+        "version": "1.9",
         "metadata": appmap_metadata,
         "events": recording.events,
         "classMap": list(classmap(recording).values()),

--- a/appmap/_implementation/testing_framework.py
+++ b/appmap/_implementation/testing_framework.py
@@ -122,8 +122,9 @@ def write_appmap(basedir, basename, contents):
 
 
 class session:
-    def __init__(self, name, version=None):
+    def __init__(self, name, recorder_type, version=None):
         self.name = name
+        self.recorder_type = recorder_type
         self.version = version
         self.metadata = None
 
@@ -139,7 +140,13 @@ class session:
 
         metadata = item.metadata
         metadata.update(
-            {"app": configuration.Config().name, "recorder": {"name": self.name}}
+            {
+                "app": configuration.Config().name,
+                "recorder": {
+                    "name": self.name,
+                    "type": self.recorder_type,
+                },
+            }
         )
 
         rec = recording.Recording()

--- a/appmap/pytest.py
+++ b/appmap/pytest.py
@@ -24,7 +24,7 @@ if appmap.enabled():
     @pytest.hookimpl
     def pytest_sessionstart(session):
         session.appmap = testing_framework.session(
-            name="pytest", version=pytest.__version__
+            name="pytest", recorder_type="tests", version=pytest.__version__
         )
 
     @pytest.hookimpl

--- a/appmap/test/data/expected.appmap.json
+++ b/appmap/test/data/expected.appmap.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4",
+  "version": "1.9",
   "metadata": {
     "language": {
       "name": "python"
@@ -165,6 +165,7 @@
           "name": "kwds",
           "kind": "keyrest",
           "class": "builtins.dict",
+          "size": 0,
           "value": "{}"
         }
       ],
@@ -210,6 +211,7 @@
           "name": "kwds",
           "kind": "keyrest",
           "class": "builtins.dict",
+          "size": 0,
           "value": "{}"
         }
       ],

--- a/appmap/test/data/pytest/expected/pytest.appmap.json
+++ b/appmap/test/data/pytest/expected/pytest.appmap.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4",
+  "version": "1.9",
   "metadata": {
     "language": {
       "name": "python"
@@ -10,7 +10,8 @@
     },
     "app": "Simple",
     "recorder": {
-      "name": "pytest"
+      "name": "pytest",
+      "type": "tests"
     },
     "recording": {
       "source_location": "test_simple.py:5"

--- a/appmap/test/data/remote.appmap.json
+++ b/appmap/test/data/remote.appmap.json
@@ -55,5 +55,5 @@
             "name": "python"
         }
     },
-    "version": "1.4"
+    "version": "1.9"
 }

--- a/appmap/test/data/trial/expected/pytest.appmap.json
+++ b/appmap/test/data/trial/expected/pytest.appmap.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4",
+  "version": "1.9",
   "metadata": {
     "language": {
       "name": "python"
@@ -18,7 +18,8 @@
     "feature": "Hello world",
     "app": "deferred",
     "recorder": {
-      "name": "pytest"
+      "name": "pytest",
+      "type": "tests"
     },
     "test_status": "succeeded"
   },

--- a/appmap/test/data/unittest/expected/pytest.appmap.json
+++ b/appmap/test/data/unittest/expected/pytest.appmap.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4",
+  "version": "1.9",
   "metadata": {
     "language": {
       "name": "python"
@@ -18,7 +18,8 @@
     "feature": "Hello world",
     "app": "Simple",
     "recorder": {
-      "name": "pytest"
+      "name": "pytest",
+      "type": "tests"
     },
     "test_status": "succeeded"
   },

--- a/appmap/test/data/unittest/expected/unittest.appmap.json
+++ b/appmap/test/data/unittest/expected/unittest.appmap.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4",
+  "version": "1.9",
   "metadata": {
     "language": {
       "name": "python"
@@ -18,7 +18,8 @@
     "feature": "Hello world",
     "app": "Simple",
     "recorder": {
-      "name": "unittest"
+      "name": "unittest",
+      "type": "tests"
     },
     "test_status": "succeeded"
   },

--- a/appmap/test/test_params.py
+++ b/appmap/test/test_params.py
@@ -17,6 +17,7 @@ empty_kwargs = {
     "name": "kwargs",
     "class": "builtins.dict",
     "kind": "keyrest",
+    "size": 0,
     "value": "{}",
 }
 
@@ -254,6 +255,7 @@ class TestInstanceMethods(TestMethodBase):
                 "name": "kwargs",
                 "class": "builtins.dict",
                 "kind": "keyrest",
+                "size": 2,
             },
         )
 

--- a/appmap/unittest.py
+++ b/appmap/unittest.py
@@ -16,7 +16,7 @@ def setup_unittest():
         logger.warning("AppMap disabled. Did you forget to set APPMAP=true?")
         return
 
-    session = testing_framework.session("unittest")
+    session = testing_framework.session("unittest", "tests")
 
     def get_test_location(cls, method_name):
         from appmap._implementation.utils import get_function_location


### PR DESCRIPTION
Increased version from 1.4 to 1.9.0
- `metadata.recorder.type` made available in 1.9.0 is now added.
- `size` made available in 1.7.0 (recommended) is now added.

Fields > 1.4 that already existed:
- `test_status` made available in 1.6.0 is already emitted.
- http response and request headers made available in 1.6.0 are already emitted.
- `normalized_path_info` made available in 1.5.1 is already emitted.
- `http_client_request` and `http_client_response` made available in 1.5.0 are already emitted.

Not emitted or not addressed:
- `eventUpdates` were not added, made available in 1.8.0.  Also missing in `appmap-ruby`
- `exception`'s `path` and  `lineno` made available in 1.6.0.  Also missing in `appmap-ruby`