### PR TITLE
fix: Require PyYAML >=5.3.0 rather than ^5.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ packages = [
 # Please update the documentation if changing the supported python version
 # https://github.com/applandinc/applandinc.github.io/blob/master/_docs/reference/appmap-python.md#supported-versions
 python = "^3.7"
-PyYAML = "^5.3.0"
+PyYAML = ">=5.3.0"
 inflection = ">=0.3.0"
 importlib-metadata = ">=0.8"
 importlib-resources = "^5.4.0"


### PR DESCRIPTION
Some packages that use appmap-python, like saleor, require PyYAML==6.0 and this conflicts with appmap-python requiring 5.3.0.

Fixes https://github.com/getappmap/appmap-python/issues/163