### PR TITLE
feat: downgrade logging level when AppMap recording is enabled

### DIFF
--- a/appmap/__init__.py
+++ b/appmap/__init__.py
@@ -1,8 +1,8 @@
 """AppMap recorder for Python"""
 from ._implementation import generation  # noqa: F401
 from ._implementation.env import Env  # noqa: F401
-from ._implementation.labels import labels  # noqa: F401
 from ._implementation.importer import instrument_module  # noqa: F401
+from ._implementation.labels import labels  # noqa: F401
 from ._implementation.recording import Recording  # noqa: F401
 
 try:

--- a/appmap/_implementation/__init__.py
+++ b/appmap/_implementation/__init__.py
@@ -1,14 +1,12 @@
 from . import configuration
 from . import env as appmapenv
 from . import event, importer, metadata, recorder
-from .detect_enabled import DetectEnabled
 from .py_version_check import check_py_version
 
 
 def initialize(**kwargs):
     check_py_version()
     appmapenv.initialize(**kwargs)
-    DetectEnabled.initialize()
     event.initialize()
     importer.initialize()
     recorder.initialize()

--- a/appmap/_implementation/configuration.py
+++ b/appmap/_implementation/configuration.py
@@ -383,6 +383,7 @@ class BuiltinFilter(MatcherFilter):
 
 
 def initialize():
+    DetectEnabled.initialize()
     Config().initialize()
     Importer.use_filter(BuiltinFilter)
     Importer.use_filter(ConfigFilter)

--- a/appmap/_implementation/env.py
+++ b/appmap/_implementation/env.py
@@ -36,6 +36,8 @@ class Env(metaclass=_EnvMeta):
         self._env = _bootenv.copy()
         if env:
             self._env.update(env)
+
+        self._configure_logging()
         self._enabled = DetectEnabled.any_enabled()
 
         self._root_dir = str(self._cwd) + "/"
@@ -43,8 +45,6 @@ class Env(metaclass=_EnvMeta):
 
         output_dir = Path(self.get("APPMAP_OUTPUT_DIR", "tmp/appmap"))
         self._output_dir = output_dir.resolve()
-
-        self._configure_logging()
 
     def set(self, name, value):
         self._env[name] = value
@@ -120,5 +120,6 @@ class Env(metaclass=_EnvMeta):
 
 
 def initialize(**kwargs):
+    DetectEnabled.initialize()
     Env.reset(**kwargs)
     logging.info("appmap enabled: %s", Env.current.enabled)

--- a/appmap/_implementation/testing_framework.py
+++ b/appmap/_implementation/testing_framework.py
@@ -140,6 +140,7 @@ def collect_result_metadata(metadata):
         metadata["exception"] = {"class": exn.__class__.__name__, "message": str(exn)}
         raise
 
+
 def file_delete(filename):
     try:
         os.remove(filename)

--- a/appmap/_implementation/web_framework.py
+++ b/appmap/_implementation/web_framework.py
@@ -135,7 +135,9 @@ class AppmapMiddleware(ABC):
         self.record_url = "/_appmap/record"
 
     def should_record(self):
-        return DetectEnabled.should_enable("remote") or DetectEnabled.should_enable("requests")
+        return DetectEnabled.should_enable("remote") or DetectEnabled.should_enable(
+            "requests"
+        )
 
     def before_request_hook(self, request, request_path, recording_is_running):
         if request_path == self.record_url:

--- a/appmap/test/test_detect_enabled.py
+++ b/appmap/test/test_detect_enabled.py
@@ -20,9 +20,21 @@ class TestDetectEnabled:
     def test_none__appmap_disabled(self):
         assert DetectEnabled.should_enable(None) == False
 
+    @patch.dict(os.environ, {"APPMAP": "False"})
+    def test_none__appmap_disabled_mixed_case(self):
+        assert DetectEnabled.should_enable(None) == False
+
     @patch.dict(os.environ, {"APPMAP": "true"})
     def test_none__appmap_enabled(self):
         # if there's no recording method then it's disabled
+        assert DetectEnabled.should_enable(None) == False
+
+    @patch.dict(os.environ, {"APPMAP": "True"})
+    def test_none__appmap_enabled_mixed_case(self):
+        assert DetectEnabled.should_enable(None) == False
+
+    @patch.dict(os.environ, {"APPMAP": "invalid_value"})
+    def test_none__appmap_invalid_value(self):
         assert DetectEnabled.should_enable(None) == False
 
     def test_invalid__no_envvar(self):
@@ -52,6 +64,22 @@ class TestDetectEnabled:
         for recording_method in RECORDING_METHODS:
             assert DetectEnabled.should_enable(recording_method) == True
 
+    recording_methods_as_true_mixed_case = {
+        key: "True" for key in recording_methods_as_true.keys()
+    }
+
+    @patch.dict(os.environ, recording_methods_as_true_mixed_case)
+    def test_some__recording_method_enabled_mixed_case(self):
+        for recording_method in RECORDING_METHODS:
+            assert DetectEnabled.should_enable(recording_method) == True
+
+    recording_methods_as_true_invalid = {"APPMAP_RECORD_INVALID": "true"}
+
+    @patch.dict(os.environ, recording_methods_as_true_invalid)
+    def test_some__recording_method_enabled_invalid(self):
+        for recording_method in RECORDING_METHODS:
+            assert DetectEnabled.should_enable(recording_method) == False
+
     recording_methods_as_false = {
         "_".join(["APPMAP", "RECORD", recording_method.upper()]): "false"
         for recording_method in RECORDING_METHODS
@@ -59,6 +87,15 @@ class TestDetectEnabled:
 
     @patch.dict(os.environ, recording_methods_as_false)
     def test_some__recording_method_disabled(self):
+        for recording_method in RECORDING_METHODS:
+            assert DetectEnabled.should_enable(recording_method) == False
+
+    recording_methods_as_false_mixed_case = {
+        key: "False" for key in recording_methods_as_false.keys()
+    }
+
+    @patch.dict(os.environ, recording_methods_as_false_mixed_case)
+    def test_some__recording_method_disabled_mixed_case(self):
         for recording_method in RECORDING_METHODS:
             assert DetectEnabled.should_enable(recording_method) == False
 

--- a/appmap/test/test_django.py
+++ b/appmap/test/test_django.py
@@ -64,7 +64,9 @@ def test_framework_metadata(
 
 
 @pytest.mark.appmap_enabled
-def test_app_can_read_body(client, events, monkeypatch):  # pylint: disable=unused-argument
+def test_app_can_read_body(
+    client, events, monkeypatch
+):  # pylint: disable=unused-argument
     monkeypatch.setenv("APPMAP_RECORD_REQUESTS", "false")
     response = client.post("/echo", json={"test": "json"})
     assert response.content == b'{"test": "json"}'

--- a/appmap/test/test_test_frameworks.py
+++ b/appmap/test/test_test_frameworks.py
@@ -41,7 +41,8 @@ def test_appmap_unittest_runner_disabled(testdir, monkeypatch):
     )
     assert result.ret == 0
     r = re.compile(r"AppMap disabled")
-    assert [l for l in filter(r.search, result.errlines)], "Warning not found"
+    # when APPMAP=false it no longer prints a warning
+    assert [l for l in filter(r.search, result.errlines)] == []
 
 
 def test_pytest_runner_unittests(testdir):

--- a/appmap/unittest.py
+++ b/appmap/unittest.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 
 def setup_unittest():
     if DetectEnabled.is_appmap_repo() or not DetectEnabled.should_enable("unittest"):
-        logger.warning("AppMap disabled. Did you forget to set APPMAP=true?")
         return
 
     session = testing_framework.session("unittest", "tests")


### PR DESCRIPTION
Don't show noise in the console.

- Show a warning when the agent does something I'm not necessarily expecting, or when I've made a mistake. So, if set `APPMAP=true`, or `APPMAP=false`, or one of the `APPMAP_RECORD_` variables is set to true or false, log at `info`.
- If any of those variables is set to a value other than `true` or `false`, write a message at `warning`. This is new behavior.
- Make the comparison with `true` or `false` be case-insensitive. Before it was done with `== "true"` and `== "false"`.
- If there's an environment variable that starts with the prefix `APPMAP_RECORD_` but doesn't match one of the supported recording types, log a message at `warning`.  This is also new behavior.
- We've gone back and forth about what level to use when recording by default. On balance, we should log this message at `info`: it's presumably exactly the behavior they were hoping for when they installed the agent, and they'll see all the AppMaps that got generated.

Fixes https://github.com/getappmap/appmap-python/issues/182.

Tested with `poetry run pytest -s -v appmap/test/test_django.py`. 