### PR TITLE
fix: use default values when config is incomplete

### DIFF
--- a/appmap.pth
+++ b/appmap.pth
@@ -1,1 +1,2 @@
-import appmap
+# The python runtime suppresses errors from import, but we should fail if something goes wrong. 
+try: import appmap; except Exception: raise

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
 set -x
-docker run -i --rm\
+t=$([ -t 0 ] && echo 't')
+docker run -i${t} --rm\
   -v $PWD/dist:/dist -v $PWD/appmap/test/data/unittest:/appmap/test/data/unittest\
   -v $PWD/ci:/ci\
   -w /tmp\
-  python:3.9 bash -ce '/ci/smoketest.sh; /ci/test_pipenv.sh'
+  python:3.9 bash -ce "${@:-/ci/smoketest.sh; /ci/test_pipenv.sh}"


### PR DESCRIPTION
If the config file is missing a value for `name` or `packages`, use the default value instead.

Fixes #181 