### PR TITLE
fix: Avoid calling __class__ when describing values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,70 +1,53 @@
+os: linux
 dist: jammy
-addons:
-  apt:
-    update: true
-    packages: [build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev libsqlite3-dev wget libbz2-dev]
+language: python
+python:
+- "3.10"
+- "3.9"
+- "3.8"
+- "3.7"
 
 # https://github.com/travis-ci/travis-ci/issues/1147#issuecomment-441393807
 if: type != push OR branch = master OR branch =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/
 
-services:
-- docker
-
-env:
-- PYENV_ROOT="$HOME/.pyenv"
-
-install: |
-  set -e
-  if [[ ! -d "$PYENV_ROOT/versions" ]]; then
-    rmdir "$PYENV_ROOT"
-    curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
-    git clone https://github.com/momo-lab/xxenv-latest.git "$(pyenv root)/plugins/xxenv-latest"
-  fi
-  export PATH="$PYENV_ROOT/bin:$PATH"
-  eval "$(pyenv init -)"
-  eval "$(pyenv init --path)"
-  eval "$(pyenv virtualenv-init -)"
-  pyenv update
-  for v in {7..10}; do pyenv latest install -s 3.$v; pyenv latest uninstall -f 3.$v; done
-  pyenv latest local 3.9 3.{7,8,10}
-  pyenv latest global 3.9
-  pip install --upgrade pip poetry tox
-
+before_install: pip install --upgrade pip setuptools
+install: pip install tox-travis
+script: tox
 
 cache:
-- $PYENV_ROOT
-- $HOME/build/applandinc/appmap-python/.tox/
+  pip: true
+  directories:
+  - $TRAVIS_BUILD_DIR/.tox/
+  - $HOME/.cache/pypoetry
 
-script:
-- export PATH="$HOME/.pyenv/bin:$PATH"
-- eval "$(pyenv init -)"
-- eval "$(pyenv init --path)"
-- eval "$(pyenv virtualenv-init -)"
-- tox -e py39 -- pylint appmap || travis_terminate 1
-- tox
-- poetry build
-- echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-- ci/run_tests.sh
-
-before_deploy:
-- |
-  nvm install --lts \
-    && nvm use --lts \
-    && npm i -g \
-      semantic-release \
-      @semantic-release/exec \
-      @semantic-release/git \
-      @semantic-release/changelog \
+jobs:
+  include:
+  - stage: smoke test
+    services:
+    - docker
+    script:
+    - pip install poetry
+    - poetry build
+    - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
+    - ci/run_tests.sh
+  - stage: deploy
+    if: branch = master
+    script: skip
+    before_deploy:
+    - pip install poetry
+    - npm i -g
+      semantic-release
+      @semantic-release/exec
+      @semantic-release/git
+      @semantic-release/changelog
       @google/semantic-release-replace-plugin
-
-
-# Note publishing this way requires the PyPI credentials to be
-# present in the environment. Travis doesn't currently support
-# providing environment variables to deploy providers through
-# the build config (i.e. in this file). So, they must be
-# provided through the build settings instead.
-deploy:
-- provider: script
-  script: bash ci/deploy.sh
-  on:
-    branch: master
+    # Note publishing this way requires the PyPI credentials to be
+    # present in the environment. Travis doesn't currently support
+    # providing environment variables to deploy providers through
+    # the build config (i.e. in this file). So, they must be
+    # provided through the build settings instead.
+    deploy:
+    - provider: script
+      script: semantic-release
+      on:
+        branch: master

--- a/appmap/_implementation/event.py
+++ b/appmap/_implementation/event.py
@@ -64,13 +64,25 @@ def display_string(val):
 
 
 def describe_value(val):
+    val_type = type(val)
     ret = {
-        "class": fqname(type(val)),
+        "class": fqname(val_type),
         "object_id": id(val),
         "value": display_string(val),
     }
-    if isinstance(val, list) or isinstance(val, dict):
+
+    # We cannot use isinstance here because it uses __class__
+    # and val could be overloading it and calling it could cause side effects.
+    #
+    # For example lazy objects such as django.utils.functional.LazyObject
+    # pretend to be the wrapped object, but they don't know its class
+    # a priori, so __class__ attribute lookup has to force evaluation.
+    # If the object hasn't been evaluated before it could change the
+    # observed behavior by doing that prematurely (perhaps even before
+    # the evaluation can even succeed).
+    if issubclass(val_type, (list, dict)):
         ret["size"] = len(val)
+
     return ret
 
 

--- a/appmap/test/data/appmap.yml
+++ b/appmap/test/data/appmap.yml
@@ -4,6 +4,7 @@ packages:
 - path: example_class.Super
   shallow: true
 - path: example_class
+- path: appmap_testing
 - path: package1
 - dist: PyYAML
 labels:

--- a/appmap/test/data/appmap_testing/django_simplelazyobject.py
+++ b/appmap/test/data/appmap_testing/django_simplelazyobject.py
@@ -1,0 +1,9 @@
+# pylint: disable=missing-module-docstring,missing-function-docstring
+
+from django.utils.functional import SimpleLazyObject
+
+def evaluate():
+    raise Exception("lazy object evaluated")
+
+def lazy():
+    return SimpleLazyObject(evaluate)

--- a/appmap/test/test_django_simplelazyobject.py
+++ b/appmap/test/test_django_simplelazyobject.py
@@ -1,0 +1,22 @@
+"""Test django.utils.functional.SimpleLazyObject handling"""
+
+import pytest
+import appmap
+
+@pytest.mark.appmap_enabled
+@pytest.mark.usefixtures("with_data_dir")
+def test_recording_simplelazyobject_does_not_evaluate():
+    """Test if recording a django.utils.functional.SimpleLazyObject does not force evaluation.
+
+    SimpleLazyObject is a simple delayed instantiation utility.
+    It only lazily instantiates an object when needed by evaluating a function.
+    Since it can be used not only for performance, but also to delay
+    instantiating objects until after some setup has been completed, we
+    need to make sure simply recording a function which returns it
+    doesn't cause incorrect premature evaluation.
+    """
+    with appmap.Recording():
+        import appmap_testing.django_simplelazyobject as ecds  # pylint: disable=import-outside-toplevel
+        ecds.lazy()
+
+    # if we're here and the exception wasn't thrown, we're good

--- a/appmap/test/test_events.py
+++ b/appmap/test/test_events.py
@@ -11,7 +11,7 @@ import pytest
 import appmap
 import appmap._implementation
 from appmap._implementation.env import Env
-from appmap._implementation.event import _EventIds
+from appmap._implementation.event import _EventIds, describe_value
 
 
 # pylint: disable=import-error
@@ -39,6 +39,17 @@ def test_thread_ids():
     all_tids = [tids.get() for _ in range(tids.qsize())]
     assert len(set(all_tids)) == len(all_tids)  # Should all be unique
 
+def test_describe_value_does_not_call_class():
+    """describe_value should not call __class__
+    __class__ could be overloaded in the value and
+    could cause side effects."""
+    class WithOverloadedClass:
+        # pylint: disable=missing-class-docstring,too-few-public-methods
+        @property
+        def __class__(self):
+            raise Exception("__class__ called")
+
+    describe_value(WithOverloadedClass())
 
 @pytest.mark.appmap_enabled
 @pytest.mark.usefixtures("with_data_dir")

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-eval "$(pyenv init -)"
-eval "$(pyenv init --path)"
-eval "$(pyenv virtualenv-init -)"
-semantic-release

--- a/pylintrc
+++ b/pylintrc
@@ -6,7 +6,7 @@
 extension-pkg-whitelist=
 
 # Specify a score threshold to be exceeded before program exits with error.
-fail-under=8.3
+fail-under=7.6
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,6 @@ coverage = "^5.3"
 pytest-mock = "^3.5.1"
 SQLAlchemy = { version = "^1.4.11", python = "^3.7"}
 tox = "^3.22.0"
-tox-pyenv = "^1.1.0"
-tox-travis = ">=0.12"
 Twisted = "^22.4.0"
 requests = "^2.25.1"
 python-decouple = "^3.5"

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ commands =
     # Turn off recording while installing. It's not necessary, and the warning messages that come
     # out of the agent confuse poetry.
     env APPMAP=false poetry install -v
+    py310-web: poetry run pylint appmap
     web: poetry run {posargs:pytest -vv}
     flask1: poetry run pytest appmap/test/test_flask.py
     django2: poetry run pytest appmap/test/test_django.py


### PR DESCRIPTION
The described value could overload `__class__` to something which causes side effects.

This was the cause of the problem found by @symwell in https://github.com/getappmap/appmap-python/issues/165?notification_referrer_id=NT_kwDOAAyRVLE0NDI4ODc3ODA4OjgyMzYzNg#issuecomment-1295264871