### PR TITLE
fix: allow scripts to be run with -m

### DIFF
--- a/appmap/command/appmap_agent_init.py
+++ b/appmap/command/appmap_agent_init.py
@@ -26,3 +26,7 @@ def _run():
 
 def run():
     sys.exit(_run())
+
+
+if __name__ == "__main__":
+    run()

--- a/appmap/command/appmap_agent_status.py
+++ b/appmap/command/appmap_agent_status.py
@@ -136,3 +136,7 @@ def run():
     )
     args = parser.parse_args()
     sys.exit(_run(discover_tests=args.discover_tests))
+
+
+if __name__ == "__main__":
+    run()

--- a/appmap/command/appmap_agent_validate.py
+++ b/appmap/command/appmap_agent_validate.py
@@ -80,3 +80,7 @@ def _run():
 
 def run():
     sys.exit(_run())
+
+
+if __name__ == "__main__":
+    run()

--- a/ci/smoketest.sh
+++ b/ci/smoketest.sh
@@ -6,11 +6,11 @@ pip install /dist/appmap-*-py3-none-any.whl
 
 cp -R /appmap/test/data/unittest/simple ./.
 
-appmap-agent-init |\
+python -m appmap.command.appmap_agent_init |\
   python -c 'import json,sys; print(json.load(sys.stdin)["configuration"]["contents"])' > /tmp/appmap.yml
 cat /tmp/appmap.yml
 
-appmap-agent-validate
+python -m appmap.command.appmap_agent_validate
 
 APPMAP=true pytest -v -k test_hello_world
 


### PR DESCRIPTION
Add `if __name__ == "__main__"` to the installer scripts so they can be run with `python -m`.

This is needed to support getappmap/appmap-js#840 .