### PR TITLE
fix: make sure FunctionWrappers can be pickled

### DIFF
--- a/appmap/test/test_recording.py
+++ b/appmap/test/test_recording.py
@@ -10,6 +10,7 @@ import pytest
 import appmap
 from appmap._implementation.event import Event
 from appmap._implementation.recorder import Recorder, ThreadRecorder
+from appmap.wrapt import FunctionWrapper
 
 from .normalize import normalize_appmap, remove_line_numbers
 
@@ -110,9 +111,22 @@ class TestRecordingWhenEnabled:
 
         rec = appmap.Recording()
         with rec:
+            assert isinstance(modfunc, FunctionWrapper)
             f1 = deepcopy(modfunc)
             f1()
 
+    def test_can_pickle(self):
+        import pickle
+
+        from example_class import (  # pyright: ignore[reportMissingImports] pylint: disable=import-error
+            modfunc,
+        )
+
+        rec = appmap.Recording()
+        with rec:
+            assert isinstance(modfunc, FunctionWrapper)
+            f = pickle.loads(pickle.dumps(modfunc))
+            f()
         evt = rec.events[-2]
         assert evt.event == "call"
         assert evt.method_id == "modfunc"


### PR DESCRIPTION
Fixes #200.

The `multiprocessing` modules requires that the callable passed to it be pickleable. Prior to these changes, passing it an instrumented function would fail with the error described in #200.

The fix for this problem is in https://github.com/getappmap/wrapt/commit/7dcec8118747b8a480c1664cad3c16ab9e86f538 . That change updates the `__reduce_ex__` method of `FunctionWrapper` so it just returns the fully-qualified name of the wrapped function. This is enough to enable the function to be pickled and unpickled, as demonstrated by the test in this PR.

You can see the failing behavior in [a previous build](https://app.travis-ci.com/github/getappmap/appmap-python/builds/258568455).