### PR TITLE
fix: don't fail on unittest subtests

### DIFF
--- a/appmap/test/data/unittest/simple/test_simple.py
+++ b/appmap/test/data/unittest/simple/test_simple.py
@@ -39,3 +39,7 @@ class UnitTestTest(unittest.TestCase):
 
     def tearDown(self):
         simple.Simple().finishUp()
+
+    def test_with_subtest(self):
+        with self.subTest("subtest"):
+            self.assertEqual(simple.Simple().hello_world("!"), "Hello world!")

--- a/appmap/test/test_test_frameworks.py
+++ b/appmap/test/test_test_frameworks.py
@@ -16,7 +16,7 @@ from .normalize import normalize_appmap
 def test_unittest_runner(testdir):
     testdir.run(sys.executable, "-m", "unittest", "-vv")
 
-    assert len(list(testdir.output().iterdir())) == 6
+    assert len(list(testdir.output().iterdir())) == 7
     verify_expected_appmap(testdir)
     verify_expected_metadata(testdir)
 
@@ -48,10 +48,10 @@ def test_appmap_unittest_runner_disabled(testdir, monkeypatch):
 def test_pytest_runner_unittests(testdir):
     testdir.test_type = "pytest"
     result = testdir.runpytest("-svv")
-    result.assert_outcomes(passed=2, failed=3, xfailed=1)
+    result.assert_outcomes(passed=3, failed=3, xfailed=1)
 
     # unittest cases run by pytest should get recorded as pytest tests
-    assert len(list(testdir.output().iterdir())) == 6
+    assert len(list(testdir.output().iterdir())) == 7
     assert len(list(testdir.path.glob("tmp/appmap/unittest/*"))) == 0
 
     verify_expected_appmap(testdir)

--- a/appmap/unittest.py
+++ b/appmap/unittest.py
@@ -34,7 +34,11 @@ def setup_unittest():
 
         test_case, is_test = _args(*args, **kwargs)
         already_recording = getattr(test_case, "_appmap_pytest_recording", None)
-        if (not is_test) or already_recording:
+        if (
+            (not is_test)
+            or isinstance(test_case, unittest.case._SubTest)
+            or already_recording
+        ):
             with wrapped(*args, **kwargs):
                 yield
             return


### PR DESCRIPTION
Make sure unittest integration can handle subtests.

Fixes #206.