### PR TITLE
feat: Add label definitions

### DIFF
--- a/_appmap/recorder.py
+++ b/_appmap/recorder.py
@@ -115,8 +115,8 @@ class Recorder(ABC):
     def _start_recording(self):
         logger.debug("AppMap recording started")
         if self._enabled:
-            logger.error("Recording already in progress, previous start:")
-            logger.error("".join(traceback.format_list(self.start_tb)))
+            logger.debug("Recording already in progress, previous start:")
+            logger.debug("".join(traceback.format_list(self.start_tb)))
             raise RuntimeError("Recording already in progress")
         self.start_tb = traceback.extract_stack()
         self._enabled = True

--- a/_appmap/test/data/expected.appmap.json
+++ b/_appmap/test/data/expected.appmap.json
@@ -11,14 +11,14 @@
   },
   "events": [
     {
-      "defined_class": "example_class.ExampleClass",
-      "method_id": "static_method",
-      "path": "_appmap/test/data/example_class.py",
       "static": true,
       "parameters": [],
       "id": 1,
       "event": "call",
-      "thread_id": 1
+      "thread_id": 1,
+      "defined_class": "example_class.ExampleClass",
+      "method_id": "static_method",
+      "path": "_appmap/test/data/example_class.py"
     },
     {
       "return_value": {
@@ -31,9 +31,6 @@
       "thread_id": 1
     },
     {
-      "defined_class": "example_class.ClassMethodMixin",
-      "method_id": "class_method",
-      "path": "_appmap/test/data/example_class.py",
       "static": true,
       "receiver": {
         "name": "cls",
@@ -44,7 +41,10 @@
       "parameters": [],
       "id": 3,
       "event": "call",
-      "thread_id": 1
+      "thread_id": 1,
+      "defined_class": "example_class.ClassMethodMixin",
+      "method_id": "class_method",
+      "path": "_appmap/test/data/example_class.py"
     },
     {
       "return_value": {
@@ -57,9 +57,6 @@
       "thread_id": 1
     },
     {
-      "defined_class": "example_class.Super",
-      "method_id": "instance_method",
-      "path": "_appmap/test/data/example_class.py",
       "static": false,
       "receiver": {
         "name": "self",
@@ -70,7 +67,10 @@
       "parameters": [],
       "id": 5,
       "event": "call",
-      "thread_id": 1
+      "thread_id": 1,
+      "defined_class": "example_class.Super",
+      "method_id": "instance_method",
+      "path": "_appmap/test/data/example_class.py"
     },
     {
       "return_value": {
@@ -83,9 +83,6 @@
       "thread_id": 1
     },
     {
-      "defined_class": "example_class.ExampleClass",
-      "method_id": "test_exception",
-      "path": "_appmap/test/data/example_class.py",
       "static": false,
       "receiver": {
         "name": "self",
@@ -96,7 +93,10 @@
       "parameters": [],
       "id": 7,
       "event": "call",
-      "thread_id": 1
+      "thread_id": 1,
+      "defined_class": "example_class.ExampleClass",
+      "method_id": "test_exception",
+      "path": "_appmap/test/data/example_class.py"
     },
     {
       "exceptions": [
@@ -111,19 +111,16 @@
       "thread_id": 1
     },
     {
-      "defined_class": "example_class.ExampleClass",
-      "method_id": "call_yaml",
-      "path": "_appmap/test/data/example_class.py",
       "static": true,
       "parameters": [],
       "id": 9,
       "event": "call",
-      "thread_id": 1
+      "thread_id": 1,
+      "defined_class": "example_class.ExampleClass",
+      "method_id": "call_yaml",
+      "path": "_appmap/test/data/example_class.py"
     },
     {
-      "defined_class": "example_class.ExampleClass",
-      "method_id": "dump_yaml",
-      "path": "_appmap/test/data/example_class.py",
       "static": true,
       "parameters": [
         {
@@ -135,12 +132,12 @@
       ],
       "id": 10,
       "event": "call",
-      "thread_id": 1
+      "thread_id": 1,
+      "defined_class": "example_class.ExampleClass",
+      "method_id": "dump_yaml",
+      "path": "_appmap/test/data/example_class.py"
     },
     {
-      "defined_class": "yaml",
-      "method_id": "dump",
-      "path": "yaml/__init__.py",
       "static": true,
       "parameters": [
         {
@@ -165,13 +162,16 @@
           "name": "kwds",
           "kind": "keyrest",
           "class": "builtins.dict",
-          "size": 0,
-          "value": "{}"
+          "value": "{}",
+          "size": 0
         }
       ],
       "id": 11,
       "event": "call",
-      "thread_id": 1
+      "thread_id": 1,
+      "defined_class": "yaml",
+      "method_id": "dump",
+      "path": "yaml/__init__.py"
     },
     {
       "return_value": {
@@ -184,9 +184,6 @@
       "thread_id": 1
     },
     {
-      "defined_class": "yaml",
-      "method_id": "dump",
-      "path": "yaml/__init__.py",
       "static": true,
       "parameters": [
         {
@@ -211,13 +208,16 @@
           "name": "kwds",
           "kind": "keyrest",
           "class": "builtins.dict",
-          "size": 0,
-          "value": "{}"
+          "value": "{}",
+          "size": 0
         }
       ],
       "id": 13,
       "event": "call",
-      "thread_id": 1
+      "thread_id": 1,
+      "defined_class": "yaml",
+      "method_id": "dump",
+      "path": "yaml/__init__.py"
     },
     {
       "return_value": {
@@ -294,7 +294,9 @@
               "type": "function",
               "location": "_appmap/test/data/example_class.py",
               "static": false,
-              "labels": ["example-label"]
+              "labels": [
+                "example-label"
+              ]
             }
           ]
         },
@@ -319,10 +321,15 @@
         {
           "name": "dump",
           "type": "function",
-          "comment": "function comment",
           "location": "yaml/__init__.py",
           "static": true,
-          "labels": ["format.yaml.generate", "serialization", "example-label"]
+          "labels": [
+            "format.yaml.generate",
+            "serialize",
+            "serialization",
+            "example-label"
+          ],
+          "comment": "function comment"
         }
       ]
     }

--- a/appmap/labeling/django.yml
+++ b/appmap/labeling/django.yml
@@ -1,0 +1,37 @@
+security.authentication:
+  - django.contrib.auth.authenticate
+  - django.contrib.auth.backends.ModelBackend.authenticate
+  - django.contrib.auth.backends.RemoteUserBackend.authenticate
+
+security.authorization:
+  - django.contrib.admin.options.BaseModelAdmin.has_add_permission
+  - django.contrib.admin.options.BaseModelAdmin.has_change_permission
+  - django.contrib.admin.options.BaseModelAdmin.has_delete_permission
+  - django.contrib.admin.options.BaseModelAdmin.has_view_permission
+  - django.contrib.admin.options.InlineModelAdmin.has_add_permission
+  - django.contrib.admin.options.InlineModelAdmin.has_change_permission
+  - django.contrib.admin.options.InlineModelAdmin.has_delete_permission
+  - django.contrib.admin.options.InlineModelAdmin.has_view_permission
+  # I don't see these ModelAdmin permissions in the code but the
+  # Django docs mention them
+  - django.contrib.admin.options.ModelAdmin.has_add_permission
+  - django.contrib.admin.options.ModelAdmin.has_change_permission
+  - django.contrib.admin.options.ModelAdmin.has_delete_permission
+  - django.contrib.admin.options.ModelAdmin.has_view_permission
+  - django.contrib.auth.backends.ModelBackend.has_perm
+  - django.contrib.auth.backends.ModelBackend.has_module_perms
+  - django.contrib.auth.backends.ModelBackend.user_can_authenticate
+  - django.contrib.auth.models.User.has_perm
+  - django.contrib.auth.models.User.has_perms
+  - django.contrib.auth.models.AnonymousUser.has_perm
+  - django.contrib.auth.models.AnonymousUser.has_perms
+  - django.contrib.auth.models.AnonymousUser.is_authenticated
+  - django.contrib.auth.models.AnonymousUser.is_anonymous
+  - django.contrib.auth.models.AnonymousUser.has_module_perms
+  - django.contrib.auth.models.AbstractBaseUser.is_authenticated
+  - django.contrib.auth.models.AbstractBaseUser.is_anonymous
+  - django.contrib.auth.models.PermissionsMixin.has_perm
+  - django.contrib.auth.models.PermissionsMixin.has_perms
+  - django.contrib.auth.models.PermissionsMixin.has_module_perms
+  # Added no entries for AbstractUser because it inherits from
+  # AbstractBaseUser, PermissionsMixin

--- a/appmap/labeling/flask.yml
+++ b/appmap/labeling/flask.yml
@@ -1,0 +1,18 @@
+security.authentication:
+ - werkzeug.security.check_password_hash
+
+security.authorization:
+ - flask_login.UserMixin.is_authenticated
+ - flask_login.UserMixin.is_active
+ - flask_login.UserMixin.is_anonymous
+ - flask_login.AnonymousUserMixin.is_authenticated
+ - flask_login.AnonymousUserMixin.is_active
+ - flask_login.AnonymousUserMixin.is_anonymous
+ - flask_authorize.has_permission
+ - flask_authorize.user_has_role
+ - flask_authorize.user_in_group
+ - flask_authorize.authorize.has_role
+ - flask_authorize.authorize.in_group
+ - flask_authorize.authorize.read
+ - flask_authorize.authorize.update
+ - flask_authorize.authorize.delete

--- a/appmap/labeling/formats.yml
+++ b/appmap/labeling/formats.yml
@@ -14,3 +14,35 @@ format.json.generate:
 format.json.parse:
   - json.loads
   - json.load
+format.pickle.generate:
+  - pickle.dumps
+  - pickle.dump
+format.pickle.parse:
+  - pickle.loads
+  - pickle.load
+format.marshal.generate:
+  - marshal.dumps
+  - marshal.dump
+format.marshal.parse:
+  - marshal.loads
+  - marshal.load
+deserialize.unsafe:
+  - yaml.load
+  - yaml.load_all
+  - pickle.loads
+  - pickle.load
+  - marshal.loads
+  - marshal.load
+deserialize.safe:
+  - json.loads
+  - json.load
+serialize:
+  - yaml.dump
+  - yaml.dump_all
+  - yaml.serialize_all
+  - json.dumps
+  - json.dump
+  - pickle.dumps
+  - pickle.dump
+  - marshal.dumps
+  - marshal.dump

--- a/appmap/labeling/jwt.yml
+++ b/appmap/labeling/jwt.yml
@@ -1,0 +1,5 @@
+jwt.encode:
+  - jwt.encode
+
+jwt.decode:
+  - jwt.decode

--- a/appmap/labeling/logger.yml
+++ b/appmap/labeling/logger.yml
@@ -1,0 +1,8 @@
+log:
+  - logging.debug
+  - logging.info
+  - logging.warning
+  - logging.error
+  - logging.critical
+  - logging.exception
+  - logging.log

--- a/appmap/labeling/random.yml
+++ b/appmap/labeling/random.yml
@@ -1,0 +1,13 @@
+pseudorandom:
+  - random.random
+
+random.insecure:
+  - random.random
+
+random.secure:
+  - os.urandom
+  - secrets.randbelow
+  - secrets.randbits
+  - secrets.token_bytes
+  - secrets.token_hex
+  - secrets.token_urlsafe


### PR DESCRIPTION
Add label definitions for Python.

Didn't see these labels added in generated AppMaps when I run the tests for an app.  I imagine it's because labels depend on https://github.com/getappmap/appmap-python/pull/218.

- `_appmap/test/data/expected.appmap.json` was changed because `poetry run pytest -v _appmap/test/test_recording.py` didn't pass without this change. Changed by saving at indent=2.
```
file_write("/tmp/generated", json.dumps(remove_line_numbers(generated_appmap), indent=2))
```
- On Django, didn't set anything related to `is_active`, `is_staff`, `is_superuser` because these seem to be fields instead of functions.

Fixes https://github.com/getappmap/appmap-python/issues/214

Depends on https://github.com/getappmap/appmap-python/issues/216