### PR TITLE
fix: don't instrument extra class members

### DIFF
--- a/_appmap/importer.py
+++ b/_appmap/importer.py
@@ -21,9 +21,9 @@ Filterable = namedtuple("Filterable", "fqname obj")
 class FilterableMod(Filterable):
     __slots__ = ()
 
-    def __new__(c, mod):
+    def __new__(cls, mod):
         fqname = mod.__name__
-        return super(FilterableMod, c).__new__(c, fqname, mod)
+        return super(FilterableMod, cls).__new__(cls, fqname, mod)
 
     def classify_fn(self, _):
         return FnType.MODULE
@@ -32,9 +32,9 @@ class FilterableMod(Filterable):
 class FilterableCls(Filterable):
     __slots__ = ()
 
-    def __new__(c, cls):
-        fqname = "%s.%s" % (cls.__module__, cls.__qualname__)
-        return super(FilterableCls, c).__new__(c, fqname, cls)
+    def __new__(cls, clazz):
+        fqname = "%s.%s" % (clazz.__module__, clazz.__qualname__)
+        return super(FilterableCls, cls).__new__(cls, fqname, clazz)
 
     def classify_fn(self, static_fn):
         return FnType.classify(static_fn)
@@ -52,9 +52,9 @@ class FilterableFn(
 ):
     __slots__ = ()
 
-    def __new__(c, scope, fn, static_fn):
+    def __new__(cls, scope, fn, static_fn):
         fqname = "%s.%s" % (scope.fqname, fn.__name__)
-        self = super(FilterableFn, c).__new__(c, fqname, fn, scope, static_fn)
+        self = super(FilterableFn, cls).__new__(cls, fqname, fn, scope, static_fn)
         return self
 
     @property
@@ -250,7 +250,7 @@ def wrapped_find_spec(find_spec, _, args, kwargs):
             # identifying methods decorated with @staticmethod. It offers two suggested fixes:
             # update the class definition, or patch the function found in __dict__. We can't do the
             # former, so do the latter instead.
-            #   https://github.com/GrahamDumpleton/wrapt/blob/68316bea668fd905a4acb21f37f12596d8c30d80/src/wrapt/wrappers.py#L691
+            #   https://github.com/GrahamDumpleton/wrapt/blob/1.14.1/src/wrapt/wrappers.py#L730
             #
             # TODO: determine if we can use wrapt.wrap_function_wrapper to simplify this code
             exec_module = inspect.getattr_static(loader, "exec_module")

--- a/_appmap/test/test_labels.py
+++ b/_appmap/test/test_labels.py
@@ -1,6 +1,6 @@
 import pytest
 
-from appmap.wrapt import BoundFunctionWrapper
+from appmap.wrapt import BoundFunctionWrapper, FunctionWrapper
 
 
 @pytest.mark.appmap_enabled
@@ -24,7 +24,7 @@ class TestLabels:
 
         verify_example_appmap(check_labels, "instance_method")
 
-    def test_instrumented_for_preset(self, verify_example_appmap):
+    def test_class_instrumented_by_preset(self, verify_example_appmap):
         def check_labels(*_):
             from http.client import (  # pyright: ignore[reportMissingImports] pylint: disable=import-error,import-outside-toplevel
                 HTTPConnection,
@@ -37,5 +37,40 @@ class TestLabels:
             assert not isinstance(
                 HTTPConnection.getresponse, BoundFunctionWrapper
             ), "HTTPConnection.getresponse should not be instrumented"
+
+        verify_example_appmap(check_labels, "instance_method")
+
+    def test_mod_instrumented_by_preset(self, verify_example_appmap):
+        def check_labels(*_):
+            import yaml  # pylint: disable=import-outside-toplevel
+
+            assert isinstance(
+                yaml.scan, FunctionWrapper
+            ), "yaml.scan should be instrumented"
+
+            assert not isinstance(
+                yaml.emit, FunctionWrapper
+            ), "yaml.emit should not be instrumented"
+
+        verify_example_appmap(check_labels, "instance_method")
+
+    def test_function_only_in_mod(self, verify_example_appmap):
+        def check_labels(*_):
+            # pylint: disable=import-outside-toplevel
+            import hmac
+
+            # pylint: enable=import-outside-toplevel
+            #
+            # It would be good to do this test, too (even though we're testing that module functions
+            # are labeled by presets). hmac.create_digest is a builtin-function, though, so this
+            # won't work until https://github.com/getappmap/appmap-python/issues/216 is fixed.
+            #
+            # assert isinstance(
+            #     hmac.create_digest, FunctionWrapper
+            # ), "hmac.compare_digest should be instrumented"
+
+            assert not isinstance(
+                hmac.HMAC.update, BoundFunctionWrapper
+            ), "hmac.HMAC.update should not be instrumented"
 
         verify_example_appmap(check_labels, "instance_method")


### PR DESCRIPTION
Prior to these changes, labeling a module function by a preset would also cause the members of classes in that module to be labeled. For example, the preset label for hmac.create_digest would cause the member functions of hmac.HMAC to be instrumented as well.

Fixes #220.