### PR TITLE
feat: add schema to event parameters

### DIFF
--- a/_appmap/test/test_describe_value.py
+++ b/_appmap/test/test_describe_value.py
@@ -1,0 +1,110 @@
+import pytest
+
+from _appmap.event import describe_value
+from _appmap.test.helpers import DictIncluding
+
+
+def test_describe_value_does_not_call_class():
+    """describe_value should not call __class__
+    __class__ could be overloaded in the value and
+    could cause side effects."""
+
+    class WithOverloadedClass:
+        # pylint: disable=missing-class-docstring,too-few-public-methods
+        @property
+        def __class__(self):
+            raise Exception("__class__ called")
+
+    describe_value(None, WithOverloadedClass())
+
+
+class TestDictValue:
+    @pytest.fixture
+    def value(self):
+        return {"id": 1, "contents": "some text"}
+
+    def test_one_level_schema(self, value):
+        actual = describe_value(None, value)
+        assert actual == DictIncluding(
+            {
+                "properties": [
+                    {"name": "id", "class": "builtins.int"},
+                    {"name": "contents", "class": "builtins.str"},
+                ]
+            }
+        )
+
+
+class TestNestedDictValue:
+    @pytest.fixture
+    def value(self):
+        return {"page": {"page_number": 1, "page_size": 20, "total": 2383}}
+
+    def test_two_level_schema(self, value):
+        actual = describe_value(None, value)
+        assert actual == DictIncluding(
+            {
+                "properties": [
+                    {
+                        "name": "page",
+                        "class": "builtins.dict",
+                        "properties": [
+                            {"name": "page_number", "class": "builtins.int"},
+                            {"name": "page_size", "class": "builtins.int"},
+                            {"name": "total", "class": "builtins.int"},
+                        ],
+                    }
+                ]
+            }
+        )
+
+    def test_respects_max_depth(self, value):
+        expected = {"properties": [{"name": "page", "class": "builtins.dict"}]}
+        actual = describe_value(None, value, max_depth=1)
+        assert actual == DictIncluding(expected)
+
+
+class TestListOfDicts:
+    @pytest.fixture
+    def value(self):
+        return [{"id": 1, "contents": "some text"}, {"id": 2}]
+
+    def test_an_array_containing_schema(self, value):
+        actual = describe_value(None, value)
+        assert actual["class"] == "builtins.list"
+        assert actual["items"][0] == DictIncluding(
+            {
+                "class": "builtins.dict",
+                "properties": [
+                    {"name": "id", "class": "builtins.int"},
+                    {"name": "contents", "class": "builtins.str"},
+                ],
+            }
+        )
+        assert actual["items"][1] == DictIncluding(
+            {
+                "class": "builtins.dict",
+                "properties": [{"name": "id", "class": "builtins.int"}],
+            }
+        )
+
+
+class TestNestedArrays:
+    @pytest.fixture
+    def value(self):
+        return [[["one"]]]
+
+    def test_arrays_ignore_max_depth(self, value):
+        actual = describe_value(None, value, max_depth=1)
+        expected = {
+            "class": "builtins.list",
+            "items": [
+                {
+                    "class": "builtins.list",
+                    "items": [
+                        {"class": "builtins.list", "items": [{"class": "builtins.str"}]}
+                    ],
+                }
+            ],
+        }
+        assert actual == DictIncluding(expected)

--- a/_appmap/test/test_events.py
+++ b/_appmap/test/test_events.py
@@ -10,7 +10,7 @@ import pytest
 
 import appmap
 from _appmap.env import Env
-from _appmap.event import _EventIds, describe_value
+from _appmap.event import _EventIds
 
 
 # pylint: disable=import-error
@@ -37,20 +37,6 @@ def test_thread_ids():
 
     all_tids = [tids.get() for _ in range(tids.qsize())]
     assert len(set(all_tids)) == len(all_tids)  # Should all be unique
-
-
-def test_describe_value_does_not_call_class():
-    """describe_value should not call __class__
-    __class__ could be overloaded in the value and
-    could cause side effects."""
-
-    class WithOverloadedClass:
-        # pylint: disable=missing-class-docstring,too-few-public-methods
-        @property
-        def __class__(self):
-            raise Exception("__class__ called")
-
-    describe_value(WithOverloadedClass())
 
 
 @pytest.mark.appmap_enabled

--- a/_appmap/test/test_params.py
+++ b/_appmap/test/test_params.py
@@ -258,6 +258,10 @@ class TestInstanceMethods(TestMethodBase):
                 "class": "builtins.dict",
                 "kind": "keyrest",
                 "size": 2,
+                "properties": [
+                    {"name": "p1", "class": "builtins.int"},
+                    {"name": "p2", "class": "builtins.int"},
+                ],
             },
         )
 

--- a/_appmap/web_framework.py
+++ b/_appmap/web_framework.py
@@ -34,7 +34,7 @@ class TemplateEvent(Event):  # pylint: disable=too-few-public-methods
 
     def __init__(self, path, instance=None):
         super().__init__("call")
-        self.receiver = describe_value(instance)
+        self.receiver = describe_value(None, instance)
         self.path = root_relative_path(path)
 
     def to_dict(self, attrs=None):


### PR DESCRIPTION
Add "properties" and "items" schemas to "parameters" objects , as specified in v1.11.0 of the appmap spec.

Fixes #226 .