### PR TITLE
fix: make sure functions can be excluded

### DIFF
--- a/_appmap/test/data/appmap-exclude-fn.yml
+++ b/_appmap/test/data/appmap-exclude-fn.yml
@@ -1,0 +1,7 @@
+
+name: TestApp
+packages:
+- path: example_class
+  exclude:
+  - ExampleClass.another_method
+- path: package1.package2.Mod1Class

--- a/_appmap/test/data/appmap-no-pyyaml.yml
+++ b/_appmap/test/data/appmap-no-pyyaml.yml
@@ -1,0 +1,13 @@
+name: TestApp
+packages:
+# note: this rule needs to go first, before the more general rule
+- path: example_class.Super
+  shallow: true
+- path: example_class
+- path: appmap_testing
+- path: package1
+labels:
+  serialization: yaml.dump
+  example-label:
+  - example_class.ExampleClass.test_exception
+  - yaml.dump

--- a/_appmap/test/test_labels.py
+++ b/_appmap/test/test_labels.py
@@ -40,6 +40,7 @@ class TestLabels:
 
         verify_example_appmap(check_labels, "instance_method")
 
+    @pytest.mark.appmap_enabled(config="appmap-no-pyyaml.yml")
     def test_mod_instrumented_by_preset(self, verify_example_appmap):
         def check_labels(*_):
             import yaml  # pylint: disable=import-outside-toplevel


### PR DESCRIPTION
Changes in 68ff82e meant that it was no longer possible to exclude a function by name. These changes make it work again.

Fixes #262.