### PR TITLE
add noappmap decorator

### DIFF
--- a/_appmap/noappmap.py
+++ b/_appmap/noappmap.py
@@ -1,0 +1,14 @@
+import sys
+
+_appmap_noappmap = "_appmap_noappmap"
+
+
+def decorator(obj):
+    setattr(obj, _appmap_noappmap, True)
+    return obj
+
+
+def disables(test_fn, cls=None):
+    return hasattr(test_fn, _appmap_noappmap) or (
+        cls is not None and hasattr(cls, _appmap_noappmap)
+    )

--- a/_appmap/test/data/pytest/test_noappmap.py
+++ b/_appmap/test/data/pytest/test_noappmap.py
@@ -1,0 +1,18 @@
+from simple import Simple
+
+import appmap
+
+
+def test_recorded():
+    print(Simple().hello_world())
+
+
+@appmap.noappmap
+def test_unrecorded_fn():
+    print(Simple().hello_world())
+
+
+@appmap.noappmap
+class TestNotRecorded:
+    def test_unrecorded_method(self):
+        print(Simple().hello_world())

--- a/_appmap/test/data/unittest/expected/pytest.appmap.json
+++ b/_appmap/test/data/unittest/expected/pytest.appmap.json
@@ -12,7 +12,7 @@
     "recording": {
       "defined_class": "simple.test_simple.UnitTestTest",
       "method_id": "test_hello_world",
-      "source_location": "simple/test_simple.py:12"
+      "source_location": "simple/test_simple.py:13"
     },
     "name": "Unit test test hello world",
     "feature": "Hello world",
@@ -28,7 +28,7 @@
       "defined_class": "simple.test_simple.UnitTestTest",
       "method_id": "test_hello_world",
       "path": "simple/test_simple.py",
-      "lineno": 13,
+      "lineno": 14,
       "static": false,
       "receiver": {
         "name": "self",
@@ -178,7 +178,7 @@
                 {
                   "name": "test_hello_world",
                   "type": "function",
-                  "location": "simple/test_simple.py:13",
+                  "location": "simple/test_simple.py:14",
                   "static": false
                 }
               ]

--- a/_appmap/test/data/unittest/expected/status_errored.metadata.json
+++ b/_appmap/test/data/unittest/expected/status_errored.metadata.json
@@ -2,7 +2,7 @@
   "test_status": "failed",
   "test_failure": {
     "message": "RuntimeError: test error",
-    "location": "simple/test_simple.py:34"
+    "location": "simple/test_simple.py:35"
   },
   "exception": {
     "class": "RuntimeError",

--- a/_appmap/test/data/unittest/expected/status_failed.metadata.json
+++ b/_appmap/test/data/unittest/expected/status_failed.metadata.json
@@ -2,7 +2,7 @@
   "test_status": "failed",
   "test_failure": {
     "message": "AssertionError: False is not true",
-    "location": "simple/test_simple.py:22"
+    "location": "simple/test_simple.py:23"
   },
   "exception": {
     "class": "AssertionError",

--- a/_appmap/test/data/unittest/expected/status_xfailed.metadata.json
+++ b/_appmap/test/data/unittest/expected/status_xfailed.metadata.json
@@ -2,7 +2,7 @@
   "test_status": "failed",
   "test_failure": {
     "message": "AssertionError: False is not true",
-    "location": "simple/test_simple.py:26"
+    "location": "simple/test_simple.py:27"
   },
   "exception": {
     "class": "AssertionError",

--- a/_appmap/test/data/unittest/expected/unittest.appmap.json
+++ b/_appmap/test/data/unittest/expected/unittest.appmap.json
@@ -12,7 +12,7 @@
     "recording": {
       "defined_class": "simple.test_simple.UnitTestTest",
       "method_id": "test_hello_world",
-      "source_location": "simple/test_simple.py:13"
+      "source_location": "simple/test_simple.py:14"
     },
     "name": "Unit test test hello world",
     "feature": "Hello world",
@@ -28,7 +28,7 @@
       "defined_class": "simple.test_simple.UnitTestTest",
       "method_id": "test_hello_world",
       "path": "simple/test_simple.py",
-      "lineno": 13,
+      "lineno": 14,
       "static": false,
       "receiver": {
         "name": "self",
@@ -178,7 +178,7 @@
                 {
                   "name": "test_hello_world",
                   "type": "function",
-                  "location": "simple/test_simple.py:13",
+                  "location": "simple/test_simple.py:14",
                   "static": false
                 }
               ]

--- a/_appmap/test/data/unittest/simple/test_noappmap.py
+++ b/_appmap/test/data/unittest/simple/test_noappmap.py
@@ -1,0 +1,11 @@
+import unittest
+
+import simple
+
+import appmap
+
+
+@appmap.noappmap
+class TestNoAppMap(unittest.TestCase):
+    def test_unrecorded(self):
+        print(simple.Simple().hello_world("!"))

--- a/_appmap/test/data/unittest/simple/test_simple.py
+++ b/_appmap/test/data/unittest/simple/test_simple.py
@@ -7,6 +7,7 @@ import simple
 # finders correctly.
 from decouple import config
 
+import appmap
 
 
 class UnitTestTest(unittest.TestCase):
@@ -42,3 +43,7 @@ class UnitTestTest(unittest.TestCase):
     def test_with_subtest(self):
         with self.subTest("subtest"):
             self.assertEqual(simple.Simple().hello_world("!"), "Hello world!")
+
+    @appmap.noappmap
+    def test_unrecorded(self):
+        print(simple.Simple().hello_world("!"))

--- a/_appmap/test/test_test_frameworks.py
+++ b/_appmap/test/test_test_frameworks.py
@@ -66,7 +66,7 @@ class TestPytestRunnerUnittest(_TestTestRunner):
     def run_tests(self, testdir):
         testdir.test_type = "pytest"
         result = testdir.runpytest("-svv")
-        result.assert_outcomes(passed=3, failed=3, xfailed=1)
+        result.assert_outcomes(passed=5, failed=3, xfailed=1)
 
     def test_enabled(self, testdir):
         self.run_tests(testdir)
@@ -86,11 +86,11 @@ class TestPytestRunnerPytest(_TestTestRunner):
 
     def run_tests(self, testdir):
         result = testdir.runpytest("-vv")
-        result.assert_outcomes(passed=1, failed=2, xpassed=1, xfailed=1)
+        result.assert_outcomes(passed=4, failed=2, xpassed=1, xfailed=1)
 
     def test_enabled(self, testdir):
         self.run_tests(testdir)
-        assert len(list(testdir.output().iterdir())) == 5
+        assert len(list(testdir.output().iterdir())) == 6
         verify_expected_appmap(testdir)
         verify_expected_metadata(testdir)
 

--- a/_appmap/unittest.py
+++ b/_appmap/unittest.py
@@ -2,7 +2,7 @@ import sys
 import unittest
 from contextlib import contextmanager
 
-from _appmap import testing_framework, wrapt
+from _appmap import noappmap, testing_framework, wrapt
 from _appmap.utils import get_function_location
 
 _session = testing_framework.session("unittest", "tests")
@@ -57,7 +57,8 @@ else:
     @wrapt.patch_function_wrapper("unittest.case", "TestCase._callTestMethod")
     def callTestMethod(wrapped, test_case, args, kwargs):
         already_recording = getattr(test_case, "_appmap_pytest_recording", None)
-        if already_recording:
+        test_method = getattr(test_case, test_case._testMethodName)
+        if already_recording or noappmap.disables(test_method, test_case.__class__):
             wrapped(*args, **kwargs)
             return
 

--- a/appmap/__init__.py
+++ b/appmap/__init__.py
@@ -3,6 +3,7 @@ from _appmap import generation  # noqa: F401
 from _appmap.env import Env  # noqa: F401
 from _appmap.importer import instrument_module  # noqa: F401
 from _appmap.labels import labels  # noqa: F401
+from _appmap.noappmap import decorator as noappmap
 from _appmap.recording import Recording  # noqa: F401
 
 try:


### PR DESCRIPTION
Add appmap.noappmap, to allow the user to disable recording of particular pytest and unittest tests.

Fixes #254 .
Fixes #255 .