### PR TITLE
move source_location property to metadata

### DIFF
--- a/_appmap/test/data/pytest/expected/pytest.appmap.json
+++ b/_appmap/test/data/pytest/expected/pytest.appmap.json
@@ -13,9 +13,7 @@
       "name": "pytest",
       "type": "tests"
     },
-    "recording": {
-      "source_location": "test_simple.py:5"
-    },
+    "source_location": "test_simple.py:5",
     "name": "hello world",
     "feature": "Hello world",
     "test_status": "succeeded"

--- a/_appmap/test/data/trial/expected/pytest.appmap.json
+++ b/_appmap/test/data/trial/expected/pytest.appmap.json
@@ -11,9 +11,9 @@
     "feature_group": "Deferred",
     "recording": {
       "defined_class": "test.test_deferred.TestDeferred",
-      "method_id": "test_hello_world",
-      "source_location": "test/test_deferred.py:7"
+      "method_id": "test_hello_world"
     },
+    "source_location": "test/test_deferred.py:7",
     "name": "Deferred hello world",
     "feature": "Hello world",
     "app": "deferred",

--- a/_appmap/test/data/unittest/expected/pytest.appmap.json
+++ b/_appmap/test/data/unittest/expected/pytest.appmap.json
@@ -11,9 +11,9 @@
     "feature_group": "Unit test test",
     "recording": {
       "defined_class": "simple.test_simple.UnitTestTest",
-      "method_id": "test_hello_world",
-      "source_location": "simple/test_simple.py:13"
+      "method_id": "test_hello_world"
     },
+    "source_location": "simple/test_simple.py:13",
     "name": "Unit test test hello world",
     "feature": "Hello world",
     "app": "Simple",

--- a/_appmap/test/data/unittest/expected/unittest.appmap.json
+++ b/_appmap/test/data/unittest/expected/unittest.appmap.json
@@ -11,9 +11,9 @@
     "feature_group": "Unit test test",
     "recording": {
       "defined_class": "simple.test_simple.UnitTestTest",
-      "method_id": "test_hello_world",
-      "source_location": "simple/test_simple.py:14"
+      "method_id": "test_hello_world"
     },
+    "source_location": "simple/test_simple.py:14",
     "name": "Unit test test hello world",
     "feature": "Hello world",
     "app": "Simple",

--- a/_appmap/testing_framework.py
+++ b/_appmap/testing_framework.py
@@ -86,9 +86,7 @@ class FuncItem:
                 "method_id": self.method_id,
             }
         if self.location:
-            ret.setdefault("recording", {}).update(
-                {"source_location": "%s:%d" % self.location[0:2]}
-            )
+            ret.update({"source_location": "%s:%d" % self.location[0:2]})
         ret.update({"name": self.scenario_name, "feature": self.feature})
         return ret
 


### PR DESCRIPTION
Correct the position of source_location in an AppMap. It should be a property of metadata, rather than metadata.recording.

Fixes #261.
