### PR TITLE
fix: Exclude the appmap test files (#271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.18.1](https://github.com/getappmap/appmap-python/compare/v1.18.0...v1.18.1) (2023-11-05)
+
+
+### Bug Fixes
+
+* move source_location property to metadata ([7ac2aa0](https://github.com/getappmap/appmap-python/commit/7ac2aa042ce89bff30dd0bd71ca3d6220d1c8ba4))
+
 # [1.18.0](https://github.com/getappmap/appmap-python/compare/v1.17.1...v1.18.0) (2023-11-04)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,18 @@ classifiers = [
         'Topic :: Software Development :: Debuggers',
         'Topic :: Software Development :: Documentation'
 ]
-include = ['appmap.pth']
+
+include = [
+    'appmap.pth',
+    { path = '_appmap/test/**/*', format = 'sdist' }
+]
+
 exclude = ['_appmap/wrapt']
 
 packages = [
-    { include = "appmap"}, {include = "_appmap" }, {include = "_appmap/wrapt", from = "vendor"}
+    { include = "appmap" },
+    { include = "_appmap/*.py" },
+    { include = "_appmap/wrapt/**/*", from = "vendor" }
 ]
 
 [tool.poetry.dependencies]
@@ -49,6 +56,7 @@ httpretty = "^1.0.5"
 pytest = "^6.1.2"
 pytest-randomly = "^3.5.0"
 pylint = "^2.6.0"
+pytest-django = "~ 4.5.2"
 flake8 = "^3.8.4"
 pyfakefs = "^4.3.2"
 pprintpp = ">=0.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "appmap"
-version = "1.18.0"
+version = "1.18.1"
 description = "Create AppMap files by recording a Python application."
 readme = "README.md"
 authors = [

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ allowlist_externals =
     poetry
 
 deps=
-    pytest-django
+    pytest-django >=4.5.2, <4.6
     web: Django >=4.0, <5.0
     web: Flask >= 2
     flask1: -rrequirements-flask1.txt


### PR DESCRIPTION
* Exclude the appmap test files

* Update glob to exclude more files

* Include the necessary files only for the sdist exclude them otherwise

* Use a lower working version of pytest-django

* Update the tox config correctly