### PR TITLE
feat: don't record by default, add runner

### DIFF
--- a/_appmap/env.py
+++ b/_appmap/env.py
@@ -3,6 +3,7 @@
 import logging
 import logging.config
 import os
+import warnings
 from contextlib import contextmanager
 from datetime import datetime
 from os import environ
@@ -10,6 +11,20 @@ from pathlib import Path
 from typing import cast
 
 from . import trace_logger
+
+_ENABLED_BY_DEFAULT_MSG = """
+
+The APPMAP environment variable is unset. Your code will be
+instrumented and recorded according to the configuration in appmap.yml.
+
+Starting with version 2, this behavior will change: when APPMAP is
+unset, no code will be instrumented. You will need to use the
+appmap-python script to run your application, or explicitly set
+APPMAP.
+
+Visit https://appmap.io/docs/reference/appmap-python.html#appmap-python-script for more
+details.
+"""
 
 _cwd = Path.cwd()
 _bootenv = environ.copy()
@@ -37,16 +52,21 @@ class _EnvMeta(type):
 
 class Env(metaclass=_EnvMeta):
     def __init__(self, env=None, cwd=None):
+        warnings.filterwarnings("once", _ENABLED_BY_DEFAULT_MSG)
+
         # root_dir and root_dir_len are going to be used when
         # instrumenting every function, so preprocess them as
         # much as possible.
+
         self._cwd = cwd or _cwd
         self._env = _bootenv.copy()
         if env:
             self._env.update(env)
 
         self._configure_logging()
-        self._enabled = self._env.get("APPMAP", "").lower() != "false"
+        enabled = self._env.get("_APPMAP", None)
+        self._enabled_by_default = enabled is None
+        self._enabled = enabled is None or enabled.lower() != "false"
 
         self._root_dir = str(self._cwd) + "/"
         self._root_dir_len = len(self._root_dir)
@@ -81,6 +101,14 @@ class Env(metaclass=_EnvMeta):
     @property
     def output_dir(self):
         return self._output_dir
+
+    @property
+    def enabled_by_default(self):
+        return self._enabled_by_default
+
+    def warn_enabled_by_default(self):
+        if self._enabled_by_default:
+            warnings.warn(_ENABLED_BY_DEFAULT_MSG, category=DeprecationWarning, stacklevel=2)
 
     @property
     def enabled(self):

--- a/_appmap/recording.py
+++ b/_appmap/recording.py
@@ -1,6 +1,6 @@
 import atexit
-from datetime import datetime, timezone
 import os
+from datetime import datetime, timezone
 from tempfile import NamedTemporaryFile
 
 from _appmap import generation
@@ -44,6 +44,7 @@ class Recording:
         return Recorder.get_enabled()
 
     def __enter__(self):
+        Env.current.warn_enabled_by_default()
         self.start()
 
     def __exit__(self, exc_type, exc_value, tb):
@@ -80,6 +81,8 @@ def write_appmap(
 
 def initialize():
     if Env.current.enables("process", "false"):
+        Env.current.warn_enabled_by_default()
+
         r = Recording()
         r.start()
 

--- a/_appmap/test/conftest.py
+++ b/_appmap/test/conftest.py
@@ -14,7 +14,6 @@ from xprocess import ProcessStarter
 
 import _appmap
 import appmap
-from _appmap.env import Env
 from _appmap.test.web_framework import TEST_HOST, TEST_PORT
 from appmap import generation
 
@@ -62,11 +61,11 @@ def pytest_runtest_setup(item):
 
         appmap_enabled = mark.kwargs.get("appmap_enabled", None)
         if isinstance(appmap_enabled, str):
-            env["APPMAP"] = appmap_enabled
+            env["_APPMAP"] = appmap_enabled
         elif appmap_enabled is False:
-            env["APPMAP"] = "false"
+            env["_APPMAP"] = "false"
         elif appmap_enabled is None:
-            env.pop("APPMAP", None)
+            env.pop("_APPMAP", None)
 
     _appmap.initialize(env=env)  # pylint: disable=protected-access
 

--- a/_appmap/test/test_configuration.py
+++ b/_appmap/test/test_configuration.py
@@ -44,15 +44,15 @@ def test_reports_invalid():
 @pytest.mark.appmap_enabled(config="appmap-broken.yml")
 def test_is_disabled_when_unset():
     """Test that recording is disabled when APPMAP is unset but the config is broken"""
-    assert Env.current.get("APPMAP", None) is None
+    assert Env.current.get("_APPMAP", None) is None
 
     assert not appmap.enabled()
 
 
 @pytest.mark.appmap_enabled(config="appmap-broken.yml", appmap_enabled="false")
 def test_is_disabled_when_false():
-    """Test that recording is disabled when APPMAP=false"""
-    Env.current.set("APPMAP", "false")
+    """Test that recording is disabled when _APPMAP=false"""
+    Env.current.set("_APPMAP", "false")
     assert not appmap.enabled()
 
 
@@ -204,7 +204,7 @@ class TestDefaultConfig(DefaultHelpers):
         assert not path.is_file()
 
         # pylint: disable=protected-access
-        _appmap.initialize(cwd=repo_root, env={"APPMAP": "false"})
+        _appmap.initialize(cwd=repo_root, env={"_APPMAP": "false"})
 
         c = Config()
         assert not path.is_file()

--- a/_appmap/test/test_django.py
+++ b/_appmap/test/test_django.py
@@ -3,7 +3,6 @@
 
 import json
 import os
-import socket
 import sys
 from pathlib import Path
 from types import SimpleNamespace as NS
@@ -16,7 +15,6 @@ import django.test
 import pytest
 from django.template.loader import render_to_string
 from django.test.client import MULTIPART_CONTENT
-from xprocess import ProcessStarter
 
 import appmap
 import appmap.django  # noqa: F401
@@ -212,7 +210,7 @@ class TestDjangoApp:
         assert "http_server_request" in events[0]
 
     def test_disabled(self, pytester, monkeypatch):
-        monkeypatch.setenv("APPMAP", "false")
+        monkeypatch.setenv("_APPMAP", "false")
         result = pytester.runpytest("-svv", "-p", "no:randomly", "-k", "test_request")
         result.assert_outcomes(passed=1, failed=0, errors=0)
         assert not (pytester.path / "tmp").exists()

--- a/_appmap/test/test_env.py
+++ b/_appmap/test/test_env.py
@@ -2,7 +2,7 @@ from _appmap.env import Env
 
 
 def test_disable_temporarily():
-    env = Env({"APPMAP": "true"})
+    env = Env({"_APPMAP": "true"})
     assert env.enables("requests")
     try:
         with env.disabled("requests"):

--- a/_appmap/test/test_fastapi.py
+++ b/_appmap/test/test_fastapi.py
@@ -1,13 +1,9 @@
 import importlib
-import socket
-import sys
 from importlib.metadata import version
-from pathlib import Path
 from types import SimpleNamespace as NS
 
 import pytest
 from fastapi.testclient import TestClient
-from xprocess import ProcessStarter
 
 import appmap
 from _appmap.env import Env

--- a/_appmap/test/test_flask.py
+++ b/_appmap/test/test_flask.py
@@ -3,21 +3,15 @@
 
 import importlib
 import os
-import socket
-import sys
-from functools import partial
 from importlib.metadata import version
-from pathlib import Path
 from types import SimpleNamespace as NS
 
 import flask
 import pytest
-from attr import dataclass
-from xprocess import ProcessStarter
+from appmap.flask import AppmapFlask
 
 from _appmap.env import Env
 from _appmap.metadata import Metadata
-from appmap.flask import AppmapFlask
 
 from ..test.helpers import DictIncluding
 from .web_framework import (
@@ -154,7 +148,7 @@ class TestFlaskApp:
         assert appmap_file.exists()
 
     def test_disabled(self, pytester, monkeypatch):
-        monkeypatch.setenv("APPMAP", "false")
+        monkeypatch.setenv("_APPMAP", "false")
 
         result = pytester.runpytest("-svv")
 

--- a/_appmap/test/test_runner.py
+++ b/_appmap/test/test_runner.py
@@ -1,0 +1,52 @@
+import re
+
+import pytest
+
+
+def test_runner_noargs(script_runner):
+    result = script_runner.run(["appmap-python"])
+    assert result.returncode != 0
+    assert result.stdout.startswith("usage")
+
+
+def test_runner_help(script_runner):
+    result = script_runner.run(["appmap-python", "--help"])
+    assert result.returncode == 0
+    assert result.stdout.startswith("usage")
+
+
+@pytest.mark.parametrize("recording_type", ["process", "pytest", "remote", "requests", "unittest"])
+def test_runner_recording_type(script_runner, recording_type):
+    result = script_runner.run(["appmap-python", "--record", recording_type])
+    assert result.returncode == 0
+    assert (
+        re.search(f"(?m)^APPMAP_RECORD_{recording_type.upper()}=true$", result.stdout) is not None
+    )
+
+    result = script_runner.run(["appmap-python", "--no-record", recording_type])
+    assert result.returncode == 0
+    assert re.search(f"(?m)^APPMAP_RECORD_{recording_type.upper()}=true$", result.stdout) is None
+
+
+@pytest.mark.parametrize("flag,expected", [("--record", 1), ("--no-record", 0)])
+def test_runner_multi_recording_type(script_runner, flag, expected):
+    types = "process,pytest"
+    result = script_runner.run(["appmap-python", flag, types])
+    assert result.returncode == 0
+    assert len(re.findall("(?m)^APPMAP_RECORD_PROCESS=true$", result.stdout)) == expected
+    assert len(re.findall("(?m)^APPMAP_RECORD_PYTEST=true$", result.stdout)) == expected
+
+
+@pytest.mark.script_launch_mode("subprocess")
+class TestEnv:
+    def test_appmap_present(self, script_runner):
+        result = script_runner.run(["appmap-python", "printenv", "APPMAP"])
+        assert result.returncode == 0
+        assert re.match(r"true", result.stdout) is not None
+
+    def test_recording_type_present(self, script_runner):
+        result = script_runner.run(
+            ["appmap-python", "--record", "process", "printenv", "APPMAP_RECORD_PROCESS"]
+        )
+        assert result.returncode == 0
+        assert re.match(r"true", result.stdout) is not None

--- a/_appmap/test/test_sqlalchemy.py
+++ b/_appmap/test/test_sqlalchemy.py
@@ -13,7 +13,7 @@ from sqlalchemy import (
     create_engine,
 )
 
-import appmap.sqlalchemy  # pylint: disable=unused-import
+import appmap.sqlalchemy  # pylint: disable=unused-import  # noqa: F401
 from _appmap.metadata import Metadata
 
 from ..test.helpers import DictIncluding
@@ -28,7 +28,9 @@ class TestSQLAlchemy(AppMapTestBase):
             {"sql": "SELECT 1", "database_type": "sqlite"}
         )
         assert events[0].sql_query["server_version"].startswith("3.")
-        assert Metadata()["frameworks"] == [{"name": "SQLAlchemy", "version": version("sqlalchemy")}]
+        assert Metadata()["frameworks"] == [
+            {"name": "SQLAlchemy", "version": version("sqlalchemy")},
+        ]
 
     @staticmethod
     # pylint: disable=unused-argument

--- a/_appmap/test/test_test_frameworks.py
+++ b/_appmap/test/test_test_frameworks.py
@@ -32,7 +32,7 @@ class _TestTestRunner(ABC):
         """Run the tests."""
 
     def test_with_appmap_false(self, testdir, monkeypatch):
-        monkeypatch.setenv("APPMAP", "false")
+        monkeypatch.setenv("_APPMAP", "false")
 
         self.run_tests(testdir)
 
@@ -165,7 +165,7 @@ def fixture_runner_testdir(request, data_dir, pytester, monkeypatch):
 
     # Make sure APPMAP isn't the environment, to test that recording-by-default is working as
     # expected. Individual test cases may set it as necessary.
-    monkeypatch.delenv("APPMAP", raising=False)
+    monkeypatch.delenv("_APPMAP", raising=False)
 
     marker = request.node.get_closest_marker("example_dir")
     test_type = "unittest" if marker is None else marker.args[0]

--- a/_appmap/unittest.py
+++ b/_appmap/unittest.py
@@ -3,6 +3,7 @@ import unittest
 from contextlib import contextmanager
 
 from _appmap import noappmap, testing_framework, wrapt
+from _appmap.env import Env
 from _appmap.utils import get_function_location
 
 _session = testing_framework.session("unittest", "tests")
@@ -42,6 +43,7 @@ if sys.version_info[1] < 8:
         with _session.record(
             test_case.__class__, method_name, location=location
         ) as metadata:
+            Env.current.warn_enabled_by_default()
             if metadata:
                 with wrapped(
                     *args, **kwargs
@@ -67,6 +69,7 @@ else:
         method_name = test_case.id().split(".")[-1]
         location = _get_test_location(test_case.__class__, method_name)
         with _session.record(test_case.__class__, method_name, location=location) as metadata:
+            Env.current.warn_enabled_by_default()
             if metadata:
                 with testing_framework.collect_result_metadata(metadata):
                     wrapped(*args, **kwargs)

--- a/_appmap/web_framework.py
+++ b/_appmap/web_framework.py
@@ -247,6 +247,8 @@ class MiddlewareInserter(ABC):
         """Return True if the AppMap middleware has enabled remote recording, False otherwise."""
 
     def run(self):
+        Env.current.warn_enabled_by_default()
+
         if not self.middleware_present():
             return self.insert_middleware()
 

--- a/appmap/__init__.py
+++ b/appmap/__init__.py
@@ -1,38 +1,44 @@
 """AppMap recorder for Python"""
+import os
 
-from _appmap import generation  # noqa: F401
-from _appmap.env import Env  # noqa: F401
-from _appmap.importer import instrument_module  # noqa: F401
-from _appmap.labels import labels  # noqa: F401
-from _appmap.noappmap import decorator as noappmap
-from _appmap.recording import Recording  # noqa: F401
+# Note that we need to guard these imports with a conditional, rather than
+# putting them in a function and conditionally calling the function. If we
+# execute the imports in a function, the modules all get put into the funtion's
+# globals, rather than into appmap's globals.
+if os.environ.get("APPMAP", "true").upper() == "TRUE":
+    from _appmap import generation  # noqa: F401
+    from _appmap.env import Env  # noqa: F401
+    from _appmap.importer import instrument_module  # noqa: F401
+    from _appmap.labels import labels  # noqa: F401
+    from _appmap.noappmap import decorator as noappmap  # noqa: F401
+    from _appmap.recording import Recording  # noqa: F401
 
-try:
-    from . import django  # noqa: F401
-except ImportError:
-    pass
+    try:
+        from . import django  # noqa: F401
+    except ImportError:
+        pass
 
-try:
-    from . import flask  # noqa: F401
-except ImportError:
-    pass
+    try:
+        from . import flask  # noqa: F401
+    except ImportError:
+        pass
 
-try:
-    from . import fastapi  # noqa: F401
-except ImportError:
-    pass
+    try:
+        from . import fastapi  # noqa: F401
+    except ImportError:
+        pass
 
-try:
-    from . import uvicorn  # noqa: F401
-except ImportError:
-    pass
+    try:
+        from . import uvicorn  # noqa: F401
+    except ImportError:
+        pass
 
-# Note: pytest integration is configured as a pytest plugin, so it doesn't need to be imported here
+    # Note: pytest integration is configured as a pytest plugin, so it doesn't
+    # need to be imported here
 
-# unittest is part of the standard library, so it should always be importable (and therefore doesn't
-# need to be in a try .. except block)
-from . import unittest  # noqa: F401
+    # unittest is part of the standard library, so it should always be
+    # importable (and therefore doesn't need to be in a try .. except block)
+    from . import unittest  # noqa: F401
 
-
-def enabled():
-    return Env.current.enabled
+    def enabled():
+        return Env.current.enabled

--- a/appmap/command/runner.py
+++ b/appmap/command/runner.py
@@ -1,0 +1,133 @@
+import argparse
+import getopt
+import os
+import sys
+import textwrap
+
+_parser = argparse.ArgumentParser(
+    description=textwrap.dedent("""
+Enable recording of the provided command, optionally specifying the
+type(s) of recording to enable and disable. If a recording type is
+specified as both enabled and disabled, it will be enabled.
+
+This command sets the environment variables described here:
+https://appmap.io/docs/reference/appmap-python.html#controlling-recording.
+For any recording type that is not explicitly specified, the
+corresponding environment variable will not be set.
+
+If no command is provided, the computed set of environment variables
+will be displayed.
+    """),
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+)
+
+_RECORDING_TYPES = set(
+    [
+        "process",
+        "pytest",
+        "remote",
+        "requests",
+        "unittest",
+    ]
+)
+
+
+def recording_types(v: str):
+    values = set(v.split(","))
+    if not values & _RECORDING_TYPES:
+        raise argparse.ArgumentTypeError(v)
+    return values
+
+
+_parser.add_argument(
+    "--record",
+    help="recording types to enable",
+    metavar=",".join(_RECORDING_TYPES),
+    type=recording_types,
+    default=argparse.SUPPRESS,
+)
+_parser.add_argument(
+    "--no-record",
+    help="recording types to disable",
+    metavar=",".join(_RECORDING_TYPES),
+    type=recording_types,
+    default=argparse.SUPPRESS,
+)
+
+if sys.version_info >= (3, 9):
+    _parser.add_argument(
+        "--enable-log",
+        help="create a log file",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
+else:
+    # You can see why BooleanOptionalAction was added. This is close, though not
+    # really as good....
+    _enable_log_group = _parser.add_mutually_exclusive_group()
+    _enable_log_group.add_argument(
+        "--enable-log",
+        help="create a log file",
+        dest="enable_log",
+        action="store_true",
+    )
+    _enable_log_group.add_argument(
+        "--no-enable-log",
+        help="don't create a log file",
+        dest="enable_log",
+        action="store_false",
+    )
+
+_parser.add_argument(
+    "command",
+    nargs="*",
+    help="the command to run (default: display the environment variables)",
+    default=argparse.SUPPRESS,
+)
+
+
+def run():
+    if len(sys.argv) == 1:
+        _parser.print_help()
+        sys.exit(1)
+
+    # Use gnu_getopt to separate the command line into args we know about,
+    # followed by the command to run (and its args)
+    try:
+        getopt_flags = ["help", "record=", "no-record=", "enable-log", "no-enable-log"]
+        opts, cmd = getopt.gnu_getopt(sys.argv[1:], "+h", getopt_flags)
+    except getopt.GetoptError as exc:
+        print(exc, file=sys.stderr)
+        _parser.print_help()
+        sys.exit(1)
+
+    # parse the args after flattening the tuples returned from gnu_getopt
+    flags = [f for opt in opts for f in opt if len(f) > 0]
+    parsed_args = _parser.parse_args(flags)
+    parsed_args = vars(parsed_args)
+
+    # our settings override those in the environment
+    envvars = {"APPMAP": "true"}
+
+    # Set the environment variables based on the the flags. A recording type in
+    # --record overrides one set in --no-record. The environment variable for a
+    # type that doesn't appear in either will be unset.
+    record = parsed_args.get("record", set())
+    no_record = parsed_args.get("no_record", set()) - record
+    for enabled in record:
+        envvars[f"APPMAP_RECORD_{enabled.upper()}"] = "true"
+    for disabled in no_record:
+        envvars[f"APPMAP_RECORD_{disabled.upper()}"] = "false"
+
+    envvars["APPMAP_DISABLE_LOG_FILE"] = "false" if parsed_args["enable_log"] else "true"
+
+    if len(cmd) == 0:
+        for k, v in sorted(envvars.items()):
+            print(f"{k}={v}")
+        sys.exit(0)
+
+    os.execvpe(cmd[0], cmd, {**os.environ, **envvars})
+
+
+if __name__ == "__main__":
+    run()

--- a/appmap/fastapi.py
+++ b/appmap/fastapi.py
@@ -59,7 +59,6 @@ class Middleware(AppmapMiddleware, BaseHTTPMiddleware):
 
     def init_app(self):
         # pylint: disable=import-outside-toplevel
-        from fastapi.middleware.wsgi import WSGIMiddleware
         from starlette.routing import Mount, Router
 
         # pylint: enable=import-outside-toplevel

--- a/appmap/pytest.py
+++ b/appmap/pytest.py
@@ -26,6 +26,10 @@ if not Env.current.is_appmap_repo and Env.current.enables("pytest"):
     logger.debug("Test recording is enabled (Pytest)")
 
     @pytest.hookimpl
+    def pytest_configure(config):
+        Env.current.warn_enabled_by_default()
+
+    @pytest.hookimpl
     def pytest_sessionstart(session):
         session.appmap = testing_framework.session(
             name="pytest", recorder_type="tests", version=version("pytest")

--- a/ci/smoketest.sh
+++ b/ci/smoketest.sh
@@ -12,7 +12,7 @@ cat /tmp/appmap.yml
 
 python -m appmap.command.appmap_agent_validate
 
-$RUNNER pytest -k test_hello_world
+$RUNNER appmap-python pytest -k test_hello_world
 
 if [[ -f tmp/appmap/pytest/simple_test_simple_UnitTestTest_test_hello_world.appmap.json ]]; then
   echo 'Success'

--- a/doc/recording-env-vars.md
+++ b/doc/recording-env-vars.md
@@ -1,0 +1,44 @@
+The tables below describe how the variable environment variables control the various
+recording types. In each case, ✓ means that the corresponding recording type
+will be produced, ❌ means that it will not.
+
+## Web Apps
+These tables describe how `APPMAP_RECORD_REQUEST` and `APPMAP_RECORD_REMOTE` are
+handled when running a web app. "web app, debug on" means a Flask app run as `flask --debug`,
+a FastAPI app run using `uvicorn --reload` and, a Django app run with `DEBUG = True` in `settings.py`.
+
+|                      | `APPMAP_RECORD_REQUEST` is unset | `APPMAP_RECORD_REQUEST` == "true" | `APPMAP_RECORD_REQUEST` == "false" |
+| -------------------- | :----------------------------: | :------------------------------: | :-------------------------------: |
+| "web app, debug on"  |               ✓                |                ✓                 |                 ❌                 |
+| "web app, debug off" |               ✓                |                ✓                 |                 ❌                 |
+
+
+|                      | `APPMAP_RECORD_REMOTE` is unset | `APPMAP_RECORD_REMOTE` == "true" | `APPMAP_RECORD_REMOTE` == "false" |
+| -------------------- | :---------------------------: | :----------------------------: | :------------------------------: |
+| "web app, debug on"  |               ✓               |               ✓                |                ❌                 |
+| "web app, debug off" |               ❌               |        ✓(with warning)         |                ❌                 |
+
+
+## Testing
+This table shows how `APPMAP_RECORD_PYTEST`, `APPMAP_RECORD_UNITTEST`, and
+`APPMAP_RECORD_REQUEST` are handled when running tests in. Note that in v2, in
+v2, `APPMAP_RECORD_PYTEST` and `APPMAP_RECORD_UNITTEST` will be replaced with
+APPMAP_RECORD_TEST.
+
+|        | `APPMAP_RECORD_PYTEST` is unset | `APPMAP_RECORD_PYTEST` == "true" | `APPMAP_RECORD_PYTEST` == "false" | `APPMAP_RECORD_REQUEST` is unset | `APPMAP_RECORD_REQUEST` == "true" | `APPMAP_RECORD_REQUEST` == "false" |
+| ------ | :---------------------------: | :-----------------------------: | :------------------------------: | :----------------------------: | :-----------------------------: | :------------------------------: |
+| pytest |               ✓               |                ✓                |                ❌                 |        ✓in v1, ❌ in v2         |                ✓                |                ❌                 |
+
+
+
+
+## Process Recording
+`APPMAP_RECORD_PROCESS` creates recordings as described in this table. Note
+that, in v1, `APPMAP_RECORD_PROCESS` doesn't change the handling of any of the
+other variables. As a result, setting it when running a either web app or when
+running tests will result in an error. Whether this behavior should change in v2
+is TBD.
+
+|                   | `APPMAP_RECORD_PROCESS` is unset | `APPMAP_RECORD_PROCESS` == "true" | `APPMAP_RECORD_PROCESS` == "false" |
+| ----------------- | :----------------------------: | :---------------------------------: | :----------------------------------: |
+| process recording |               ❌                |                  ✓                  |                  ❌                   |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ uvicorn = "^0.27.1"
 fastapi = "^0.110.0"
 httpx = "^0.27.0"
 pytest-env = "^1.1.3"
+pytest-console-scripts = "^1.4.1"
 
 [build-system]
 requires = ["poetry-core>=1.1.0"]
@@ -91,6 +92,7 @@ appmap = "appmap.pytest"
 appmap-agent-init = "appmap.command.appmap_agent_init:run"
 appmap-agent-status = "appmap.command.appmap_agent_status:run"
 appmap-agent-validate = "appmap.command.appmap_agent_validate:run"
+appmap-python = "appmap.command.runner:run"
 
 [tool.black]
 line-length = 102

--- a/tox.ini
+++ b/tox.ini
@@ -18,13 +18,11 @@ deps=
 
 
 commands =
-    # Turn off recording while installing. It's not necessary, and the warning messages that come
-    # out of the agent confuse poetry.
-    env APPMAP_LOG_LEVEL=warning APPMAP=false poetry install -v
-    py310-web: bash -c "poetry run pylint -j 0 appmap _appmap || pylint-exit $?"
-    web: poetry run {posargs:pytest}
-    django3: poetry run pytest _appmap/test/test_django.py
-    flask2: poetry run pytest _appmap/test/test_flask.py
+    poetry install -v
+    py310-web: poetry run pylint -j 0 appmap _appmap
+    web: poetry run appmap-python {posargs:pytest}
+    django3: poetry run appmap-python pytest _appmap/test/test_django.py
+    flask2: poetry run appmap-python pytest _appmap/test/test_flask.py
 
 [testenv:vendoring]
 skip_install = True


### PR DESCRIPTION
**https://github.com/getappmap/applandinc.github.io/pull/1325 needs to be merged before this.**

These change begin the transition of a change in the agent's behavior. In version 2.0 (the next version released), instrumentation will no longer be automatically enabled after it's installed in a Python environment. To create recordings, the environment variable `APPMAP` must be set to `true` (case-insensitive).

In addition, there is now a runner script, `appmap-python`. It can be used to control the environment variables, including `APPMAP_DISABLE_LOG_FILE`.

Fixes #294 .