### PR TITLE
feat: Check malformed path entries

### DIFF
--- a/_appmap/__init__.py
+++ b/_appmap/__init__.py
@@ -1,6 +1,5 @@
-from . import configuration
+from . import configuration, event, importer, metadata, recorder, recording, web_framework
 from . import env as appmapenv
-from . import event, importer, metadata, recorder, recording, web_framework
 from .py_version_check import check_py_version
 
 

--- a/_appmap/env.py
+++ b/_appmap/env.py
@@ -10,6 +10,8 @@ from os import environ
 from pathlib import Path
 from typing import cast
 
+from _appmap.singleton import SingletonMeta
+
 from . import trace_logger
 
 _ENABLED_BY_DEFAULT_MSG = """
@@ -34,23 +36,7 @@ def _recording_method_key(recording_method):
     return f"APPMAP_RECORD_{recording_method.upper()}"
 
 
-class _EnvMeta(type):
-    def __init__(cls, *args, **kwargs):
-        type.__init__(cls, *args, **kwargs)
-        cls._instance = None
-
-    @property
-    def current(cls):
-        if not cls._instance:
-            cls._instance = Env()
-
-        return cls._instance
-
-    def reset(cls, **kwargs):
-        cls._instance = Env(**kwargs)
-
-
-class Env(metaclass=_EnvMeta):
+class Env(metaclass=SingletonMeta):
     def __init__(self, env=None, cwd=None):
         warnings.filterwarnings("once", _ENABLED_BY_DEFAULT_MSG)
 

--- a/_appmap/importer.py
+++ b/_appmap/importer.py
@@ -189,7 +189,7 @@ class Importer:
         # Import Config here, to avoid circular top-level imports.
         from .configuration import Config  # pylint: disable=import-outside-toplevel
 
-        package_functions = Config().package_functions
+        package_functions = Config.current.package_functions
         fm = FilterableMod(mod)
         if fm.fqname in package_functions:
             instrument_functions(fm, package_functions.get(fm.fqname))

--- a/_appmap/singleton.py
+++ b/_appmap/singleton.py
@@ -1,0 +1,14 @@
+class SingletonMeta(type):
+    def __init__(cls, *args, **kwargs):
+        type.__init__(cls, *args, **kwargs)
+        cls._instance = None
+
+    @property
+    def current(cls):
+        if not cls._instance:
+            cls._instance = cls()
+
+        return cls._instance
+
+    def reset(cls, **kwargs):
+        cls._instance = cls(**kwargs)

--- a/_appmap/test/data/appmap-all-paths-malformed.yml
+++ b/_appmap/test/data/appmap-all-paths-malformed.yml
@@ -1,0 +1,9 @@
+name: TestApp
+packages:
+- path: abc/xyz
+- path: abc\xyz
+- path: \abc
+- path: xyz/
+- path: 42
+- path: .
+- path: 

--- a/_appmap/test/data/appmap-empty-path.yml
+++ b/_appmap/test/data/appmap-empty-path.yml
@@ -1,0 +1,5 @@
+name: TestApp
+packages:
+  - path: example_class
+  - path:
+

--- a/_appmap/test/data/appmap-malformed-path.yml
+++ b/_appmap/test/data/appmap-malformed-path.yml
@@ -1,0 +1,4 @@
+name: TestApp
+packages:
+- path: example_class
+- path: package1/package2/Mod1Class

--- a/_appmap/test/test_configuration.py
+++ b/_appmap/test/test_configuration.py
@@ -26,7 +26,7 @@ def test_can_be_configured():
     """
     assert appmap.enabled()
 
-    c = Config()
+    c = Config.current
     assert c.file_present
     assert c.file_valid
 
@@ -38,7 +38,7 @@ def test_reports_invalid():
     indicates that the config is not valid.
     """
     assert not appmap.enabled()
-    assert not Config().file_valid
+    assert not Config.current.file_valid
 
 
 @pytest.mark.appmap_enabled(config="appmap-broken.yml")
@@ -62,9 +62,9 @@ def test_config_not_found(caplog):
             "APPMAP_CONFIG": "notfound.yml",
         }
     )
-    assert Config().name is None
-    assert not Config().file_present
-    assert not Config().file_valid
+    assert Config.current.name is None
+    assert not Config.current.file_present
+    assert not Config.current.file_valid
 
     assert not appmap.enabled()
     not_found = Path("notfound.yml").resolve()
@@ -80,7 +80,7 @@ def test_config_no_message(caplog):
     """
 
     assert not appmap.enabled()
-    assert Config().name is None
+    assert Config.current.name is None
     assert caplog.text == ""
 
 
@@ -129,7 +129,7 @@ class DefaultHelpers:
     def check_default_config(self, expected_name):
         assert appmap.enabled()
 
-        default_config = Config()
+        default_config = Config.current
         assert default_config.name == expected_name
         self.check_default_packages(default_config.packages)
         assert default_config.default["appmap_dir"] == "tmp/appmap"
@@ -160,7 +160,7 @@ class TestDefaultConfig(DefaultHelpers):
                 "APPMAP_CONFIG": "/tmp/appmap.yml",
             }
         )
-        assert not Config().name
+        assert not Config.current.name
         assert not appmap.enabled()
 
     def test_exclusions(self, data_dir, tmpdir, mocker, monkeypatch):
@@ -186,7 +186,7 @@ class TestDefaultConfig(DefaultHelpers):
         # pylint: disable=protected-access
         _appmap.initialize(cwd=repo_root)
 
-        Config()  # write the file as a side-effect
+        Config.current  # write the file as a side-effect
         assert path.is_file()
         with open(path, encoding="utf-8") as cfg:
             actual_config = yaml.safe_load(cfg)
@@ -206,7 +206,7 @@ class TestDefaultConfig(DefaultHelpers):
         # pylint: disable=protected-access
         _appmap.initialize(cwd=repo_root, env={"_APPMAP": "false"})
 
-        c = Config()
+        c = Config.current
         assert not path.is_file()
 
 
@@ -257,7 +257,7 @@ class TestSearchConfig:
 
         # pylint: disable=protected-access
         _appmap.initialize(cwd=project_root)
-        assert Config().name == "config-up-name"
+        assert Config.current.name == "config-up-name"
         assert str(Env.current.output_dir).endswith(str(tmpdir / "tmp" / "appmap"))
 
     def test_config_not_found_until_repo_root(self, data_dir, tmpdir, git_directory, monkeypatch):
@@ -272,7 +272,7 @@ class TestSearchConfig:
         # It should stop searching at repo_root.
         # Check that it did not find appmap.yml
         # in config-up folder.
-        assert Config().name != "config-up-name"
+        assert Config.current.name != "config-up-name"
         # It should go on with default config
         assert Env.current.enabled
 
@@ -286,6 +286,6 @@ class TestSearchConfig:
             cwd=project_root,
             env={"APPMAP_CONFIG": "notfound.yml"},
         )
-        Config()
+        Config.current
         # No default config since we specified APPMAP_CONFIG
         assert not Env.current.enabled

--- a/_appmap/test/test_configuration.py
+++ b/_appmap/test/test_configuration.py
@@ -120,6 +120,27 @@ class TestConfiguration:
         f = Filterable(None, "package1_prefix.cls", None)
         assert cf().filter(f) is False
 
+    def test_malformed_path(self, data_dir, caplog):
+        _appmap.initialize(env={"APPMAP_CONFIG": "appmap-malformed-path.yml"}, cwd=data_dir)
+        Config.current._load_config(show_warnings=True)
+        assert (
+            "Malformed path value 'package1/package2/Mod1Class' in configuration file. "
+            "Path entries must be module names not directory paths."
+            in caplog.text
+        )
+
+    def test_all_paths_malformed(self, data_dir):
+        _appmap.initialize(env={"APPMAP_CONFIG": "appmap-all-paths-malformed.yml"}, cwd=data_dir)
+        assert len(Config().packages) == 0
+
+    def test_empty_path(self, data_dir, caplog):
+        _appmap.initialize(env={"APPMAP_CONFIG": "appmap-empty-path.yml"}, cwd=data_dir)
+        Config.current._load_config(show_warnings=True)
+        assert (
+            "Missing path value in configuration file."
+            in caplog.text
+        )
+
 
 class DefaultHelpers:
     def check_default_packages(self, actual_packages):

--- a/_appmap/testing_framework.py
+++ b/_appmap/testing_framework.py
@@ -106,7 +106,7 @@ class session:  # pylint: disable=too-few-public-methods
         metadata = item.metadata
         metadata.update(
             {
-                "app": configuration.Config().name,
+                "app": configuration.Config.current.name,
                 "recorder": {
                     "name": self.name,
                     "type": self.recorder_type,

--- a/appmap/command/appmap_agent_init.py
+++ b/appmap/command/appmap_agent_init.py
@@ -12,7 +12,7 @@ def _run():
             {
                 "configuration": {
                     "filename": "appmap.yml",
-                    "contents": yaml.dump(Config().default),
+                    "contents": yaml.dump(Config.current.default),
                 }
             }
         )

--- a/appmap/command/appmap_agent_status.py
+++ b/appmap/command/appmap_agent_status.py
@@ -68,7 +68,7 @@ def has_unittest_tests():
 
 
 def _run(*, discover_tests):
-    config = Config()
+    config = Config.current
     uses_pytest = has_dist("pytest")
 
     has_tests = None


### PR DESCRIPTION
Fixes #302

Warning and dropping malformed configuration file package path entries, which cannot be parsed as Python module names: `mod1/mod2`, `mod1\mod2`, `123`, `.`, ` `.