### PR TITLE
disable recording by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,12 @@ reenabled as soon as possible.]
 ### pytest
 
 Note that you must install the dependencies contained in
-[requirements-test.txt](requirements-test.txt) before running tests. See the explanation in
+[requirements-dev.txt](requirements-dev.txt) before running tests. See the explanation in
 [pyproject.toml](pyproject.toml) for details.
+
+Additionally, the tests currently require that you set `APPMAP=true`. You can
+either run `pytest` with `appmap-python` (see [tox.ini](tox.ini)), or you can explicitly
+set the environment variable.
 
 [pytest](https://docs.pytest.org/en/stable/) for testing:
 

--- a/_appmap/env.py
+++ b/_appmap/env.py
@@ -21,6 +21,7 @@ def _recording_method_key(recording_method):
 
 
 class Env(metaclass=SingletonMeta):
+    RECORD_PROCESS_DEFAULT = "false"
 
     def __init__(self, env=None, cwd=None):
         # root_dir and root_dir_len are going to be used when
@@ -93,8 +94,19 @@ class Env(metaclass=SingletonMeta):
         if not self.enabled:
             return False
 
-        v = self.get(_recording_method_key(recording_method), default).lower()
-        return v != "false"
+        process_enabled = self._enables("process", self.RECORD_PROCESS_DEFAULT)
+        if recording_method == "process":
+            return process_enabled
+
+        # If process recording is enabled, others should be disabled
+        if process_enabled:
+            return False
+
+        # Otherwise, check the environment variable
+        return self._enables(recording_method, default)
+
+    def _enables(self, recording_method, default):
+        return self.get(_recording_method_key(recording_method), default).lower() != "false"
 
     @contextmanager
     def disabled(self, recording_method: str):

--- a/_appmap/env.py
+++ b/_appmap/env.py
@@ -3,7 +3,6 @@
 import logging
 import logging.config
 import os
-import warnings
 from contextlib import contextmanager
 from os import environ
 from pathlib import Path
@@ -12,20 +11,6 @@ from typing import cast
 from _appmap.singleton import SingletonMeta
 
 from . import trace_logger
-
-_ENABLED_BY_DEFAULT_MSG = """
-
-The APPMAP environment variable is unset. Your code will be
-instrumented and recorded according to the configuration in appmap.yml.
-
-Starting with version 2, this behavior will change: when APPMAP is
-unset, no code will be instrumented. You will need to use the
-appmap-python script to run your application, or explicitly set
-APPMAP.
-
-Visit https://appmap.io/docs/reference/appmap-python.html#appmap-python-script for more
-details.
-"""
 
 _cwd = Path.cwd()
 _bootenv = environ.copy()
@@ -36,9 +21,8 @@ def _recording_method_key(recording_method):
 
 
 class Env(metaclass=SingletonMeta):
-    def __init__(self, env=None, cwd=None):
-        warnings.filterwarnings("once", _ENABLED_BY_DEFAULT_MSG)
 
+    def __init__(self, env=None, cwd=None):
         # root_dir and root_dir_len are going to be used when
         # instrumenting every function, so preprocess them as
         # much as possible.
@@ -54,7 +38,6 @@ class Env(metaclass=SingletonMeta):
 
         self._configure_logging()
         enabled = self._env.get("_APPMAP", None)
-        self._enabled_by_default = enabled is None
         self._enabled = enabled is None or enabled.lower() != "false"
 
         self._root_dir = str(self._cwd) + "/"
@@ -97,14 +80,6 @@ class Env(metaclass=SingletonMeta):
     @output_dir.setter
     def output_dir(self, value):
         self._output_dir = value
-
-    @property
-    def enabled_by_default(self):
-        return self._enabled_by_default
-
-    def warn_enabled_by_default(self):
-        if self._enabled_by_default:
-            warnings.warn(_ENABLED_BY_DEFAULT_MSG, category=DeprecationWarning, stacklevel=2)
 
     @property
     def enabled(self):

--- a/_appmap/env.py
+++ b/_appmap/env.py
@@ -73,6 +73,9 @@ class Env(metaclass=SingletonMeta):
     def set(self, name, value):
         self._env[name] = value
 
+    def setdefault(self, name, default_value):
+        self._env.setdefault(name, default_value)
+
     def get(self, name, default=None):
         return self._env.get(name, default)
 
@@ -122,7 +125,7 @@ class Env(metaclass=SingletonMeta):
     def disabled(self, recording_method: str):
         key = _recording_method_key(recording_method)
         value = self.get(key)
-        self.set(key, "false")
+        self.setdefault(key, "false")
         try:
             yield
         finally:

--- a/_appmap/recording.py
+++ b/_appmap/recording.py
@@ -79,7 +79,7 @@ def write_appmap(
 
 
 def initialize():
-    if Env.current.enables("process", "false"):
+    if Env.current.enables("process", Env.RECORD_PROCESS_DEFAULT):
         r = Recording()
         r.start()
 

--- a/_appmap/recording.py
+++ b/_appmap/recording.py
@@ -44,7 +44,6 @@ class Recording:
         return Recorder.get_enabled()
 
     def __enter__(self):
-        Env.current.warn_enabled_by_default()
         self.start()
 
     def __exit__(self, exc_type, exc_value, tb):
@@ -81,8 +80,6 @@ def write_appmap(
 
 def initialize():
     if Env.current.enables("process", "false"):
-        Env.current.warn_enabled_by_default()
-
         r = Recording()
         r.start()
 

--- a/_appmap/test/test_configuration.py
+++ b/_appmap/test/test_configuration.py
@@ -16,10 +16,6 @@ from _appmap.env import Env
 from _appmap.importer import Filterable, NullFilter
 
 
-def test_enabled_by_default():
-    assert appmap.enabled()
-
-
 @pytest.mark.appmap_enabled
 def test_can_be_configured():
     """
@@ -45,8 +41,6 @@ def test_reports_invalid():
 @pytest.mark.appmap_enabled(config="appmap-broken.yml")
 def test_is_disabled_when_unset():
     """Test that recording is disabled when APPMAP is unset but the config is broken"""
-    assert Env.current.get("_APPMAP", None) is None
-
     assert not appmap.enabled()
 
 

--- a/_appmap/test/test_django.py
+++ b/_appmap/test/test_django.py
@@ -216,6 +216,19 @@ class TestDjangoApp:
         result.assert_outcomes(passed=1, failed=0, errors=0)
         assert not (pytester.path / "tmp").exists()
 
+    def test_disabled_for_process(self, pytester, monkeypatch):
+        monkeypatch.setenv("APPMAP_RECORD_PROCESS", "true")
+
+        result = pytester.runpytest("-svv")
+
+        # There are two tests for remote recording. They should both fail,
+        # because process recording should disable remote recording.
+        result.assert_outcomes(passed=2, failed=2, errors=0)
+
+        assert (pytester.path / "tmp" / "appmap" / "process").exists()
+        assert not (pytester.path / "tmp" / "appmap" / "requests").exists()
+        assert not (pytester.path / "tmp" / "appmap" / "pytest").exists()
+
 
 @pytest.fixture(name="server")
 def django_server(xprocess, server_base):

--- a/_appmap/test/test_flask.py
+++ b/_appmap/test/test_flask.py
@@ -8,10 +8,10 @@ from types import SimpleNamespace as NS
 
 import flask
 import pytest
-from appmap.flask import AppmapFlask
 
 from _appmap.env import Env
 from _appmap.metadata import Metadata
+from appmap.flask import AppmapFlask
 
 from ..test.helpers import DictIncluding
 from .web_framework import (
@@ -144,7 +144,11 @@ class TestFlaskApp:
         appmap_file = (
             pytester.path / "tmp" / "appmap" / "pytest" / "test_request.appmap.json"
         )
+
+        # No request recordings should have been created
         assert not os.path.exists(pytester.path / "tmp" / "appmap" / "requests")
+
+        # but there should be a test recording
         assert appmap_file.exists()
 
     def test_disabled(self, pytester, monkeypatch):
@@ -154,3 +158,14 @@ class TestFlaskApp:
 
         result.assert_outcomes(passed=1, failed=0, errors=0)
         assert not (pytester.path / "tmp" / "appmap").exists()
+
+    def test_disabled_for_process(self, pytester, monkeypatch):
+        monkeypatch.setenv("APPMAP_RECORD_PROCESS", "true")
+
+        result = pytester.runpytest("-svv")
+
+        result.assert_outcomes(passed=1, failed=0, errors=0)
+
+        assert (pytester.path / "tmp" / "appmap" / "process").exists()
+        assert not (pytester.path / "tmp" / "appmap" / "requests").exists()
+        assert not (pytester.path / "tmp" / "appmap" / "pytest").exists()

--- a/_appmap/test/test_runner.py
+++ b/_appmap/test/test_runner.py
@@ -15,7 +15,7 @@ def test_runner_help(script_runner):
     assert result.stdout.startswith("usage")
 
 
-@pytest.mark.parametrize("recording_type", ["process", "pytest", "remote", "requests", "unittest"])
+@pytest.mark.parametrize("recording_type", ["process", "remote", "requests", "tests"])
 def test_runner_recording_type(script_runner, recording_type):
     result = script_runner.run(["appmap-python", "--record", recording_type])
     assert result.returncode == 0

--- a/_appmap/test/test_test_frameworks.py
+++ b/_appmap/test/test_test_frameworks.py
@@ -39,7 +39,7 @@ class _TestTestRunner(ABC):
         assert not testdir.output().exists()
 
     def test_disabled(self, testdir, monkeypatch):
-        monkeypatch.setenv(f"APPMAP_RECORD_{self._test_type.upper()}", "false")
+        monkeypatch.setenv("APPMAP_RECORD_TESTS", "false")
 
         self.run_tests(testdir)
         assert not testdir.output().exists()

--- a/_appmap/test/test_test_frameworks.py
+++ b/_appmap/test/test_test_frameworks.py
@@ -44,6 +44,13 @@ class _TestTestRunner(ABC):
         self.run_tests(testdir)
         assert not testdir.output().exists()
 
+    def test_disabled_for_process(self, testdir, monkeypatch):
+        monkeypatch.setenv("APPMAP_RECORD_PROCESS", "true")
+
+        self.run_tests(testdir)
+        assert (testdir.path / "tmp" / "appmap" / "process").exists()
+        assert not testdir.output().exists()
+
 
 class TestUnittestRunner(_TestTestRunner):
     @classmethod

--- a/_appmap/unittest.py
+++ b/_appmap/unittest.py
@@ -3,7 +3,6 @@ import unittest
 from contextlib import contextmanager
 
 from _appmap import noappmap, testing_framework, wrapt
-from _appmap.env import Env
 from _appmap.utils import get_function_location
 
 _session = testing_framework.session("unittest", "tests")
@@ -43,7 +42,6 @@ if sys.version_info[1] < 8:
         with _session.record(
             test_case.__class__, method_name, location=location
         ) as metadata:
-            Env.current.warn_enabled_by_default()
             if metadata:
                 with wrapped(
                     *args, **kwargs
@@ -69,7 +67,6 @@ else:
         method_name = test_case.id().split(".")[-1]
         location = _get_test_location(test_case.__class__, method_name)
         with _session.record(test_case.__class__, method_name, location=location) as metadata:
-            Env.current.warn_enabled_by_default()
             if metadata:
                 with testing_framework.collect_result_metadata(metadata):
                     wrapped(*args, **kwargs)

--- a/_appmap/web_framework.py
+++ b/_appmap/web_framework.py
@@ -250,8 +250,6 @@ class MiddlewareInserter(ABC):
         """Return True if the AppMap middleware has enabled remote recording, False otherwise."""
 
     def run(self):
-        Env.current.warn_enabled_by_default()
-
         if not self.middleware_present():
             return self.insert_middleware()
 

--- a/appmap/__init__.py
+++ b/appmap/__init__.py
@@ -9,40 +9,40 @@ _enabled = os.environ.get("APPMAP", None)
 if _enabled is None or _enabled.upper() == "TRUE":
     if _enabled is not None:
         # Use setdefault so tests can manage _APPMAP as necessary
-        os.environ["_APPMAP"] = _enabled
-    from _appmap import generation  # noqa: F401
-    from _appmap.env import Env  # noqa: F401
-    from _appmap.importer import instrument_module  # noqa: F401
-    from _appmap.labels import labels  # noqa: F401
-    from _appmap.noappmap import decorator as noappmap  # noqa: F401
-    from _appmap.recording import Recording  # noqa: F401
+        os.environ.setdefault("_APPMAP", _enabled)
+        from _appmap import generation  # noqa: F401
+        from _appmap.env import Env  # noqa: F401
+        from _appmap.importer import instrument_module  # noqa: F401
+        from _appmap.labels import labels  # noqa: F401
+        from _appmap.noappmap import decorator as noappmap  # noqa: F401
+        from _appmap.recording import Recording  # noqa: F401
 
-    try:
-        from . import django  # noqa: F401
-    except ImportError:
-        pass
+        try:
+            from . import django  # noqa: F401
+        except ImportError:
+            pass
 
-    try:
-        from . import flask  # noqa: F401
-    except ImportError:
-        pass
+        try:
+            from . import flask  # noqa: F401
+        except ImportError:
+            pass
 
-    try:
-        from . import fastapi  # noqa: F401
-    except ImportError:
-        pass
+        try:
+            from . import fastapi  # noqa: F401
+        except ImportError:
+            pass
 
-    try:
-        from . import uvicorn  # noqa: F401
-    except ImportError:
-        pass
+        try:
+            from . import uvicorn  # noqa: F401
+        except ImportError:
+            pass
 
-    # Note: pytest integration is configured as a pytest plugin, so it doesn't
-    # need to be imported here
+        # Note: pytest integration is configured as a pytest plugin, so it doesn't
+        # need to be imported here
 
-    # unittest is part of the standard library, so it should always be
-    # importable (and therefore doesn't need to be in a try .. except block)
-    from . import unittest  # noqa: F401
+        # unittest is part of the standard library, so it should always be
+        # importable (and therefore doesn't need to be in a try .. except block)
+        from . import unittest  # noqa: F401
 
-    def enabled():
-        return Env.current.enabled
+        def enabled():
+            return Env.current.enabled

--- a/appmap/command/runner.py
+++ b/appmap/command/runner.py
@@ -24,10 +24,9 @@ will be displayed.
 _RECORDING_TYPES = set(
     [
         "process",
-        "pytest",
         "remote",
         "requests",
-        "unittest",
+        "tests",
     ]
 )
 

--- a/appmap/pytest.py
+++ b/appmap/pytest.py
@@ -26,10 +26,6 @@ if not Env.current.is_appmap_repo and Env.current.enables("tests"):
     logger.debug("Test recording is enabled (Pytest)")
 
     @pytest.hookimpl
-    def pytest_configure(config):  # pylint: disable=unused-argument
-        Env.current.warn_enabled_by_default()
-
-    @pytest.hookimpl
     def pytest_sessionstart(session):
         session.appmap = testing_framework.session(
             name="pytest", recorder_type="tests", version=version("pytest")

--- a/appmap/pytest.py
+++ b/appmap/pytest.py
@@ -22,7 +22,7 @@ class recorded_testcase:  # pylint: disable=too-few-public-methods
                 return wrapped(*args, **kwargs)
 
 
-if not Env.current.is_appmap_repo and Env.current.enables("pytest"):
+if not Env.current.is_appmap_repo and Env.current.enables("tests"):
     logger.debug("Test recording is enabled (Pytest)")
 
     @pytest.hookimpl

--- a/appmap/unittest.py
+++ b/appmap/unittest.py
@@ -2,7 +2,7 @@ from _appmap.env import Env
 
 logger = Env.current.getLogger(__name__)
 
-if not Env.current.is_appmap_repo and Env.current.enables("unittest"):
+if not Env.current.is_appmap_repo and Env.current.enables("tests"):
     logger.debug("Test recording is enabled (unittest)")
     # pylint: disable=unused-import
     import _appmap.unittest  # pyright: ignore   # noqa: F401

--- a/docs/recording-env-vars.md
+++ b/docs/recording-env-vars.md
@@ -3,11 +3,11 @@ recording types. In each case, ✓ means that the corresponding recording type
 will be produced, ❌ means that it will not.
 
 ## Web Apps
-These tables describe how `APPMAP_RECORD_REQUEST` and `APPMAP_RECORD_REMOTE` are
+These tables describe how `APPMAP_RECORD_REQUESTS` and `APPMAP_RECORD_REMOTE` are
 handled when running a web app. "web app, debug on" means a Flask app run as `flask --debug`,
 a FastAPI app run using `uvicorn --reload` and, a Django app run with `DEBUG = True` in `settings.py`.
 
-|                      | `APPMAP_RECORD_REQUEST` is unset | `APPMAP_RECORD_REQUEST` == "true" | `APPMAP_RECORD_REQUEST` == "false" |
+|                      | `APPMAP_RECORD_REQUESTS` is unset | `APPMAP_RECORD_REQUESTS` == "true" | `APPMAP_RECORD_REQUESTS` == "false" |
 | -------------------- | :----------------------------: | :------------------------------: | :-------------------------------: |
 | "web app, debug on"  |               ✓                |                ✓                 |                 ❌                 |
 | "web app, debug off" |               ✓                |                ✓                 |                 ❌                 |
@@ -21,13 +21,13 @@ a FastAPI app run using `uvicorn --reload` and, a Django app run with `DEBUG = T
 
 ## Testing
 This table shows how `APPMAP_RECORD_PYTEST`, `APPMAP_RECORD_UNITTEST`, and
-`APPMAP_RECORD_REQUEST` are handled when running tests in. Note that in v2, in
+`APPMAP_RECORD_REQUESTS` are handled when running tests in. Note that in v2, in
 v2, `APPMAP_RECORD_PYTEST` and `APPMAP_RECORD_UNITTEST` will be replaced with
-APPMAP_RECORD_TEST.
+`APPMAP_RECORD_TESTS`.
 
-|        | `APPMAP_RECORD_PYTEST` is unset | `APPMAP_RECORD_PYTEST` == "true" | `APPMAP_RECORD_PYTEST` == "false" | `APPMAP_RECORD_REQUEST` is unset | `APPMAP_RECORD_REQUEST` == "true" | `APPMAP_RECORD_REQUEST` == "false" |
+|        | `APPMAP_RECORD_PYTEST` is unset | `APPMAP_RECORD_PYTEST` == "true" | `APPMAP_RECORD_PYTEST` == "false" | `APPMAP_RECORD_REQUESTS` is unset | `APPMAP_RECORD_REQUESTS` == "true" | `APPMAP_RECORD_REQUESTS` == "false" |
 | ------ | :---------------------------: | :-----------------------------: | :------------------------------: | :----------------------------: | :-----------------------------: | :------------------------------: |
-| pytest |               ✓               |                ✓                |                ❌                 |        ✓in v1, ❌ in v2         |                ✓                |                ❌                 |
+| pytest |               ✓               |                ✓                |                ❌                 |        ❌         |                ignored in v1, ✓ in v2                |                ❌                 |
 
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,14 +24,12 @@ deps=
 
 commands =
     poetry install -v
-    web: poetry run {posargs:pytest}
-    django3: poetry run pytest _appmap/test/test_django.py
-    flask2: poetry run pytest _appmap/test/test_flask.py
-    sqlalchemy1: poetry run pytest _appmap/test/test_sqlalchemy.py
+    web: poetry run appmap-python {posargs:pytest}
+    django3: poetry run appmap-python pytest _appmap/test/test_django.py
+    flask2: poetry run appmap-python pytest _appmap/test/test_flask.py
+    sqlalchemy1: poetry run appmap-python pytest _appmap/test/test_sqlalchemy.py
 
 [testenv:lint]
-setenv =
-    APPMAP=false
 skip_install = True
 deps =
     poetry


### PR DESCRIPTION
The agent no longer records by default. Code must be run with `appmap-python`, or with `APPMAP=true` to create AppMap data files.

Additionally, `APPMAP_RECORD_PYTEST` and `APPMAP_RECORD_UNITTEST` have been replaced by `APPMAP_RECORD_TESTS`. Also, `APPMAP_RECORD_PROCESS` now disables other recording types.

Fixes #299.
Fixes #300.
Fixes #301.
Fixes #307.
