### PR TITLE
fix SQLAlchemy deprecated execute param in test

### DIFF
--- a/appmap/sqlalchemy.py
+++ b/appmap/sqlalchemy.py
@@ -15,7 +15,7 @@ from _appmap.recorder import Recorder
 @event.listens_for(Engine, "before_cursor_execute")
 # pylint: disable=too-many-arguments,unused-argument
 def capture_sql_call(conn, cursor, statement, parameters, context, executemany):
-    """Capture SQL query callinto appmap."""
+    """Capture SQL query call into appmap."""
     if is_instrumentation_disabled():
         # We must be in the middle of fetching object representation.
         # Don't record this query in the appmap.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ packaging = ">=19.0"
 # install it and the rest of the dev dependencies.
 
 [tool.poetry.group.dev.dependencies]
-SQLAlchemy = "^1.4.11"
 Twisted = "^22.4.0"
 asgiref = "^3.7.2"
 black = "^24.2.0"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ flask >=2, <= 3
 pytest-django<4.8
 fastapi
 httpx
+sqlalchemy

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,3 @@
 django ~= 3.2
 pytest-django < 4.8
+sqlalchemy < 2.0

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 isolated_build = true
 # The *-web environments test the latest versions of Django and Flask with the full test suite. For
 # older version of the web frameworks, just run the tests that are specific to them.
-envlist = py3{8,9,10,11,12}-{web,django3,flask2}
+envlist = py3{8,9,10,11,12}-{web,django3,flask2,sqlalchemy1}
 
 [testenv]
 allowlist_externals =
@@ -13,9 +13,10 @@ deps=
     poetry
     web: Django >=4.0, <5.0
     web: Flask >=3.0
+    web: sqlalchemy >=2.0, <3.0
     flask2: Flask >= 2.0, <3.0
     django3: Django >=3.2, <4.0
-
+    sqlalchemy1: sqlalchemy >=1.4.11, <2.0
 
 commands =
     poetry install -v
@@ -23,6 +24,7 @@ commands =
     web: poetry run appmap-python {posargs:pytest}
     django3: poetry run appmap-python pytest _appmap/test/test_django.py
     flask2: poetry run appmap-python pytest _appmap/test/test_flask.py
+    sqlalchemy1: poetry run appmap-python pytest _appmap/test/test_sqlalchemy.py
 
 [testenv:vendoring]
 skip_install = True


### PR DESCRIPTION
Fixes #279.

- Fixed deprecated usages in tests. 
 -- Passing a string to `Conneciton.execute()` is deprecated in SQLAlchemy 1.4 and removed in 2.0: https://docs.sqlalchemy.org/en/14/core/connections.html#sqlalchemy.engine.Connection.execute
-- Changed the tests with warnings issuing a DML with `Connection.execute()` to be explicit about commit behavior since auto-commit behavior is changed in 2.0: https://docs.sqlalchemy.org/en/20/changelog/migration_20.html
- Updated tox config to test with both 1.4 and 2.0 versions of SQLAlchemy.
