### PR TITLE
fix: handle non json serializable types

### DIFF
--- a/_appmap/test/data/pytest/expected/pytest.appmap.json
+++ b/_appmap/test/data/pytest/expected/pytest.appmap.json
@@ -8,95 +8,133 @@
       "name": "appmap",
       "url": "https://github.com/applandinc/appmap-python"
     },
+    "source_location": "test_simple.py:5",
+    "name": "hello world",
+    "feature": "Hello world",
     "app": "Simple",
     "recorder": {
       "name": "pytest",
       "type": "tests"
     },
-    "source_location": "test_simple.py:5",
-    "name": "hello world",
-    "feature": "Hello world",
     "test_status": "succeeded"
   },
   "events": [
     {
-      "defined_class": "simple.Simple",
-      "method_id": "hello_world",
-      "path": "simple.py",
-      "lineno": 8,
       "static": false,
       "receiver": {
-        "class": "simple.Simple",
         "kind": "req",
+        "value": "<simple.Simple object at 0xabcdef>",
         "name": "self",
-        "value": "<simple.Simple object at 0xabcdef>"
+        "class": "simple.Simple"
       },
       "parameters": [],
       "id": 1,
       "event": "call",
-      "thread_id": 1
+      "thread_id": 1,
+      "defined_class": "simple.Simple",
+      "method_id": "hello_world",
+      "path": "simple.py",
+      "lineno": 16
     },
     {
-      "defined_class": "simple.Simple",
-      "method_id": "hello",
-      "path": "simple.py",
-      "lineno": 2,
       "static": false,
       "receiver": {
-        "class": "simple.Simple",
         "kind": "req",
+        "value": "<simple.Simple object at 0xabcdef>",
         "name": "self",
-        "value": "<simple.Simple object at 0xabcdef>"
+        "class": "simple.Simple"
       },
       "parameters": [],
       "id": 2,
       "event": "call",
-      "thread_id": 1
+      "thread_id": 1,
+      "defined_class": "simple.Simple",
+      "method_id": "get_non_json_serializable",
+      "path": "simple.py",
+      "lineno": 13
+    },
+    {
+      "static": false,
+      "receiver": {
+        "kind": "req",
+        "value": "<simple.Simple object at 0xabcdef>",
+        "name": "self",
+        "class": "simple.Simple"
+      },
+      "parameters": [],
+      "id": 3,
+      "event": "call",
+      "thread_id": 1,
+      "defined_class": "simple.Simple",
+      "method_id": "hello",
+      "path": "simple.py",
+      "lineno": 7
     },
     {
       "return_value": {
-        "class": "builtins.str",
-        "value": "'Hello'"
+        "value": "'Hello'",
+        "class": "builtins.str"
       },
-      "parent_id": 2,
-      "id": 3,
+      "parent_id": 3,
+      "id": 4,
       "event": "return",
       "thread_id": 1
     },
     {
+      "static": false,
+      "receiver": {
+        "kind": "req",
+        "value": "<simple.Simple object at 0xabcdef>",
+        "name": "self",
+        "class": "simple.Simple"
+      },
+      "parameters": [],
+      "id": 5,
+      "event": "call",
+      "thread_id": 1,
       "defined_class": "simple.Simple",
       "method_id": "world",
       "path": "simple.py",
-      "lineno": 5,
-      "static": false,
-      "receiver": {
-        "class": "simple.Simple",
-        "kind": "req",
-        "name": "self",
-        "value": "<simple.Simple object at 0xabcdef>"
-      },
-      "parameters": [],
-      "id": 4,
-      "event": "call",
-      "thread_id": 1
+      "lineno": 10
     },
     {
       "return_value": {
-        "class": "builtins.str",
-        "value": "'world!'"
+        "value": "'world!'",
+        "class": "builtins.str"
       },
-      "parent_id": 4,
-      "id": 5,
+      "parent_id": 5,
+      "id": 6,
       "event": "return",
       "thread_id": 1
     },
     {
       "return_value": {
-        "class": "builtins.str",
-        "value": "'Hello world!'"
+        "value": "{0: 'Hello', 1: 'world!'}",
+        "class": "builtins.dict",
+        "properties": [
+          {
+            "name": "0",
+            "class": "builtins.str"
+          },
+          {
+            "name": "1",
+            "class": "builtins.str"
+          }
+        ],
+        "size": 2
+      },
+      "parent_id": 2,
+      "id": 7,
+      "event": "return",
+      "thread_id": 1
+    },
+    {
+      "return_value": {
+        "value": "'Hello world!'",
+        "class": "builtins.str"
       },
       "parent_id": 1,
-      "id": 6,
+      "id": 8,
       "event": "return",
       "thread_id": 1
     }
@@ -111,21 +149,27 @@
           "type": "class",
           "children": [
             {
+              "name": "get_non_json_serializable",
+              "type": "function",
+              "location": "simple.py:13",
+              "static": false
+            },
+            {
               "name": "hello",
               "type": "function",
-              "location": "simple.py:2",
+              "location": "simple.py:7",
               "static": false
             },
             {
               "name": "hello_world",
               "type": "function",
-              "location": "simple.py:8",
+              "location": "simple.py:16",
               "static": false
             },
             {
               "name": "world",
               "type": "function",
-              "location": "simple.py:5",
+              "location": "simple.py:10",
               "static": false
             }
           ]

--- a/_appmap/test/data/pytest/simple.py
+++ b/_appmap/test/data/pytest/simple.py
@@ -1,3 +1,8 @@
+import numpy
+
+zero = numpy.int64(0)
+one = numpy.int64(1)
+
 class Simple:
     def hello(self):
         return "Hello"
@@ -5,5 +10,9 @@ class Simple:
     def world(self):
         return "world!"
 
+    def get_non_json_serializable(self):
+        return { zero: self.hello(), one: self.world() }
+
     def hello_world(self):
-        return "%s %s" % (self.hello(), self.world())
+        result = self.get_non_json_serializable()
+        return "%s %s" % (result[zero], result[one])

--- a/_appmap/test/test_generation.py
+++ b/_appmap/test/test_generation.py
@@ -1,4 +1,9 @@
+import json
 import pytest
+
+import numpy as np
+
+from _appmap.generation import AppMapEncoder
 
 
 @pytest.mark.appmap_enabled
@@ -48,3 +53,18 @@ class TestGeneration:
             return ret
 
         verify_example_appmap(check_comment, "instance_method")
+
+class TestAppMapEncoder:
+    def test_np_int64_type(self):
+        data = {
+            "value": np.int64(42),
+        }
+        json_str = json.dumps(data, cls=AppMapEncoder)
+        assert '{"value": "42"}' == json_str
+
+    def test_np_array_type(self):
+        data = {
+            "value": np.array([0, 1, 2, 3])
+        }
+        json_str = json.dumps(data, cls=AppMapEncoder)
+        assert '{"value": "[0 1 2 3]"}' == json_str

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ fastapi
 httpx
 sqlalchemy
 debugpy
+numpy

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,8 @@ allowlist_externals =
 deps=
     poetry
     web: {[web-deps]deps}
+    py38: numpy==1.24.4
+    py3{9,10,11,12}: numpy >=1.26
     flask2: Flask >= 2.0, <3.0
     django3: Django >=3.2, <4.0
     sqlalchemy1: sqlalchemy >=1.4.11, <2.0


### PR DESCRIPTION
Fixes #283.
 
- Adds `numpy` as a dev dependency. v1.24.4 is the latest version supporting Python 3.8.
- Changes `tox.ini` to support different `numpy` versions in Python 3.8 and 3.{9,10,11,12}
- Adds tests for `AppMapEncoder` ensuring objects containing members with `numpy.int64` and `numpy.array` types can be serialized without errors.
- Modifies a test that generates an AppMap to cover the issue.