### PR TITLE
fix: handle non json serializable types

### DIFF
--- a/_appmap/env.py
+++ b/_appmap/env.py
@@ -38,7 +38,7 @@ class Env(metaclass=SingletonMeta):
                     self._env.pop(k, None)
 
         self._configure_logging()
-        enabled = self._env.get("_APPMAP", None)
+        enabled = self._env.get("_APPMAP", "false")
         self._enabled = enabled is None or enabled.lower() != "false"
 
         self._root_dir = str(self._cwd) + "/"

--- a/_appmap/generation.py
+++ b/_appmap/generation.py
@@ -111,7 +111,10 @@ class AppMapEncoder(json.JSONEncoder):
         if isinstance(o, ClassMapEntry):
             return o.to_dict()
 
-        return json.JSONEncoder.default(self, o)
+        try:
+            return json.JSONEncoder.default(self, o)
+        except TypeError:
+            return str(o)
 
 
 def dump(recording, metadata=None, indent=None):

--- a/appmap/__init__.py
+++ b/appmap/__init__.py
@@ -46,3 +46,7 @@ if _enabled is None or _enabled.upper() == "TRUE":
 
         def enabled():
             return Env.current.enabled
+    else:
+        os.environ.pop("_APPMAP", None)
+else:
+    os.environ.setdefault("_APPMAP", "false")

--- a/appmap/command/runner.py
+++ b/appmap/command/runner.py
@@ -106,7 +106,10 @@ def run():
     parsed_args = vars(parsed_args)
 
     # our settings override those in the environment
-    envvars = {"APPMAP": "true"}
+    envvars = {
+        "APPMAP": "true",
+        "_APPMAP": "true",
+    }
 
     # Set the environment variables based on the the flags. A recording type in
     # --record overrides one set in --no-record. The environment variable for a

--- a/ci/smoketest.sh
+++ b/ci/smoketest.sh
@@ -6,13 +6,15 @@ pip -q install /dist/appmap-*-py3-none-any.whl
 
 cp -R /_appmap/test/data/unittest/simple ./.
 
+export APPMAP=true
+
 python -m appmap.command.appmap_agent_init |\
   python -c 'import json,sys; print(json.load(sys.stdin)["configuration"]["contents"])' > /tmp/appmap.yml
 cat /tmp/appmap.yml
 
 python -m appmap.command.appmap_agent_validate
 
-$RUNNER appmap-python pytest -k test_hello_world
+$RUNNER pytest -k test_hello_world
 
 if [[ -f tmp/appmap/pytest/simple_test_simple_UnitTestTest_test_hello_world.appmap.json ]]; then
   echo 'Success'


### PR DESCRIPTION
With these changes, the string representation of the object will appear in the AppMap. This works well for `numpy.int64`, for example, but it's possible that it will fail for other types.

This has no tests, as yet, soon to be added in https://github.com/getappmap/appmap-python/pull/310 .

Also, while testing this, I noticed a couple of places where record-by-default was still not disabled properly. These changes address them.