### PR TITLE
fix: expect a missing config file

### DIFF
--- a/_appmap/configuration.py
+++ b/_appmap/configuration.py
@@ -482,8 +482,7 @@ _startup_messages_shown = os.environ.get("_APPMAP_MESSAGES_SHOWN")
 if _startup_messages_shown is None:
     # pylint: disable=protected-access
     c._load_config(show_warnings=True)
-    logger.info("file: %s", c._file)
-    logger.info("config: %s", c._config)
+    logger.info("file: %s", c._file if c.file_present else "[no appmap.yml]")
     logger.debug("package_functions: %s", c.package_functions)
     logger.info("env: %r", os.environ)
     os.environ["_APPMAP_MESSAGES_SHOWN"] = "true"

--- a/ci/smoketest.sh
+++ b/ci/smoketest.sh
@@ -6,6 +6,9 @@ pip -q install /dist/appmap-*-py3-none-any.whl
 
 cp -R /_appmap/test/data/unittest/simple ./.
 
+# Before we enable, run a command that tries to load the config
+python -m appmap.command.appmap_agent_status
+
 export APPMAP=true
 
 python -m appmap.command.appmap_agent_init |\


### PR DESCRIPTION
If mapping is disabled, attempting to load file config won't create a new file. Expect this can happen, and don't crash.

Fixes #323 .