### PR TITLE
fix: ask pytest not to rewrite our modules

### DIFF
--- a/_appmap/__init__.py
+++ b/_appmap/__init__.py
@@ -1,3 +1,5 @@
+"""PYTEST_DONT_REWRITE"""
+
 from . import configuration, event, importer, metadata, recorder, recording, web_framework
 from . import env as appmapenv
 from .py_version_check import check_py_version

--- a/appmap/__init__.py
+++ b/appmap/__init__.py
@@ -1,4 +1,6 @@
-"""AppMap recorder for Python"""
+"""AppMap recorder for Python
+PYTEST_DONT_REWRITE
+"""
 import os
 
 # Note that we need to guard these imports with a conditional, rather than

--- a/ci/smoketest.sh
+++ b/ci/smoketest.sh
@@ -17,7 +17,8 @@ cat /tmp/appmap.yml
 
 python -m appmap.command.appmap_agent_validate
 
-$RUNNER pytest -k test_hello_world
+# Promote warnings to errors, so we'll fail if pytest warns it can't rewrite appmap
+$RUNNER pytest -Werror -k test_hello_world
 
 if [[ -f tmp/appmap/pytest/simple_test_simple_UnitTestTest_test_hello_world.appmap.json ]]; then
   echo 'Success'


### PR DESCRIPTION
Make sure that when we get loaded as a pytest plugin, pytest doesn't try to rewrite our modules. This avoids a warning about being unable to do the rewrite, which will cause test failures if warnings have been promoted to errors (e.g. with warnings.simplefilter("error")).

As far as I can tell, this change doesn't affect our internal tests, and we still get proper error messages when one of our assertions fails. Even if this turns out not be true, though, pytest rewriting is cosmetic only: an assertion failure still raises an exception and the test will fail. It just won't have a pretty message.

Fixes #314 .