### PR TITLE
fix: appmap.Recording is available even when APPMAP=false

### DIFF
--- a/_appmap/recording.py
+++ b/_appmap/recording.py
@@ -54,6 +54,33 @@ class Recording:
         return False
 
 
+class NoopRecording:
+    """
+    A noop context manager to export as "Recording" instead of class
+    Recording when not Env.current.enabled.
+    """
+
+    def __init__(self, exit_hook=None):
+        self.exit_hook = exit_hook
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def is_running(self):
+        return False
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_value, tb):
+        if self.exit_hook is not None:
+            self.exit_hook(self)
+        return False
+
+
 def write_appmap(
     appmap, appmap_fname, recorder_type, metadata=None, basedir=Env.current.output_dir
 ):

--- a/appmap/__init__.py
+++ b/appmap/__init__.py
@@ -8,6 +8,7 @@ import os
 # execute the imports in a function, the modules all get put into the funtion's
 # globals, rather than into appmap's globals.
 _enabled = os.environ.get("APPMAP", None)
+_recording_exported = False
 if _enabled is None or _enabled.upper() == "TRUE":
     if _enabled is not None:
         # Use setdefault so tests can manage _APPMAP as necessary
@@ -18,6 +19,7 @@ if _enabled is None or _enabled.upper() == "TRUE":
         from _appmap.labels import labels  # noqa: F401
         from _appmap.noappmap import decorator as noappmap  # noqa: F401
         from _appmap.recording import Recording  # noqa: F401
+        _recording_exported = True
 
         try:
             from . import django  # noqa: F401
@@ -52,3 +54,10 @@ if _enabled is None or _enabled.upper() == "TRUE":
         os.environ.pop("_APPMAP", None)
 else:
     os.environ.setdefault("_APPMAP", "false")
+
+if not _recording_exported:
+    # Client code that imports appmap.Recording should run correctly
+    # even when not Env.current.enabled (not APPMAP=true).
+    # This prevents:
+    #   ImportError: cannot import name 'Recording' from 'appmap'...
+    from _appmap.recording import NoopRecording as Recording # noqa: F401

--- a/ci/smoketest.sh
+++ b/ci/smoketest.sh
@@ -1,5 +1,24 @@
 #!/usr/bin/env bash
 
+test_recording_when_appmap_not_true()
+{
+  cat <<EOF > test_client.py
+from appmap import Recording
+
+with Recording():
+  print("Hello from appmap library client")
+EOF
+
+  python test_client.py
+
+  if [[ $? -eq 0 ]]; then
+    echo 'Script executed successfully'
+  else
+    echo 'Script execution failed'
+    exit 1
+  fi
+}
+
 set -ex
 pip -q install -U pip pytest "flask>=2,<3" python-decouple
 pip -q install /dist/appmap-*-py3-none-any.whl
@@ -8,6 +27,9 @@ cp -R /_appmap/test/data/unittest/simple ./.
 
 # Before we enable, run a command that tries to load the config
 python -m appmap.command.appmap_agent_status
+
+# Ensure that client code using appmap.Recording does not fail when not APPMAP=true
+test_recording_when_appmap_not_true
 
 export APPMAP=true
 


### PR DESCRIPTION
Fixes #326.

- Adds `NoopRecording` class with the same interface as `Recording`.
- Exports `NoopRecording` as `Recording` when `APPMAP` is not set to `true` to prevent "ImportError: cannot import name 'Recording' from 'appmap' ..." in client code.
- Extends [`smoketest.sh`](https://github.com/getappmap/appmap-python/blob/325a58b7981f7e994626b29193ba89e4814bc8d4/ci/smoketest.sh#L31-L48) to ensure that client code using `appmap.Recording` does not fail when `APPMAP=false`.