### PR TITLE
fix: optionally limit number of events collected

### DIFF
--- a/_appmap/instrument.py
+++ b/_appmap/instrument.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from . import event
 from .env import Env
 from .event import CallEvent
-from .recorder import Recorder
+from .recorder import Recorder, AppMapTooManyEvents
 from .utils import appmap_tls
 
 logger = Env.current.getLogger(__name__)
@@ -97,6 +97,8 @@ def call_instrumented(f, instance, args, kwargs):
         )
         Recorder.add_event(return_event)
         return ret
+    except AppMapTooManyEvents:
+        raise
     except Exception:  # noqa: E722
         elapsed_time = time.time() - start_time
         Recorder.add_event(


### PR DESCRIPTION
If the environment variable APPMAP_MAX_EVENTS is set, use it to limit the number of events added to a Recorder. This setting is a suggestion, rather than a hard limit, but the Recorder should get close.

Fixes #329 .

In the interest of getting this out ASAP, it doesn't have any additional tests. It shouldn't have any impact when it's unset, which is shown by the fact that all the existing tests pass.