### PR TITLE
fix: use an RLock in SharedRecorder._add_event

### DIFF
--- a/_appmap/recorder.py
+++ b/_appmap/recorder.py
@@ -191,7 +191,7 @@ class SharedRecorder(Recorder):
     A shared Recorder. The global recorder is an instance of this class.
     """
 
-    _lock = threading.Lock()
+    _lock = threading.RLock()
 
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
It's possible that when adding an event to the global recorder, the current thread will try to add another event. This happens in Django's tests, because it uses weak references with instrumented finalizers. Calling _add_event can cause the weak reference to get garbage collected, resulting in a call to the finalizer, which will also call _add_event.

Fixes #333 .