### PR TITLE
Add APPMAP_MAX_TIME

### DIFF
--- a/_appmap/event.py
+++ b/_appmap/event.py
@@ -111,7 +111,9 @@ def describe_value(name, val, max_depth=5):
         "object_id": id(val),
         "value": display_string(val),
     }
-    ret.update(_describe_schema(name, val, 0, max_depth))
+    if Env.current.display_params:
+        ret.update(_describe_schema(name, val, 0, max_depth))
+
     if any(_is_list_or_dict(type(val))):
         ret["size"] = len(val)
 

--- a/_appmap/instrument.py
+++ b/_appmap/instrument.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from . import event
 from .env import Env
 from .event import CallEvent
-from .recorder import Recorder, AppMapTooManyEvents
+from .recorder import Recorder, AppMapLimitExceeded
 from .utils import appmap_tls
 
 logger = Env.current.getLogger(__name__)
@@ -90,6 +90,7 @@ def call_instrumented(f, instance, args, kwargs):
     call_event_id = call_event.id
     start_time = time.time()
     try:
+        Recorder.check_time(start_time)
         ret = f.fn(*args, **kwargs)
         elapsed_time = time.time() - start_time
 
@@ -98,7 +99,7 @@ def call_instrumented(f, instance, args, kwargs):
         )
         Recorder.add_event(return_event)
         return ret
-    except AppMapTooManyEvents:
+    except AppMapLimitExceeded:
         raise
     except Exception:  # noqa: E722
         elapsed_time = time.time() - start_time

--- a/vendor/_appmap/wrapt/wrappers.py
+++ b/vendor/_appmap/wrapt/wrappers.py
@@ -457,9 +457,11 @@ class ObjectProxy(with_metaclass(_ObjectProxyMetaType)):
         raise NotImplementedError(
                 'object proxy must define __reduce_ex__()')
 
+    # Return the qualname of the wrapped function instead of a tuple. This allows an instance of
+    # subclasses to be pickled as the function it wraps. This seems to be adequate for generating
+    # AppMaps.
     def __reduce_ex__(self, protocol):
-        raise NotImplementedError(
-                'object proxy must define __reduce_ex__()')
+         return self.__wrapped__.__qualname__
 
 class CallableObjectProxy(ObjectProxy):
 
@@ -740,12 +742,9 @@ class FunctionWrapper(_FunctionWrapperBase):
     # new FunctionWrapper will be created. If it doesn't, then __reduce_ex__ can simply return a
     # string, which would cause deepcopy to return the original FunctionWrapper.
     #
-    # Update: We'll return the qualname of the wrapped function instead of a tuple allows a
-    # FunctionWrapper to be pickled (as the function it wraps). This seems to be adequate for
-    # generating AppMaps, so go with that.
 
-    def __reduce_ex__(self, protocol):
-         return self.__wrapped__.__qualname__
+    # def __reduce_ex__(self, protocol):
+    #      return self.__wrapped__.__qualname__
  
          # return FunctionWrapper, (
          #     self.__wrapped__,


### PR DESCRIPTION
Add `APPMAP_MAX_TIME` which allows the user to specify, in seconds, the maximum time a recording session should be allowed.

In addition, disable rendering of the schema associated with values (parameter, return types) when `APPMAP_DISPLAY_PARAMS=false`.

Finally, move the implementation of `__reduce_ex__` from `wrapt.wrappers.FunctionWrapper` up to `ObjectProxy`. Our implementation, which is good enough for generating AppMaps, works for any instance of an ObjectProxy.