### PR TITLE
fix: request recording in unittest setUp method

### DIFF
--- a/_appmap/test/data/django/test/test_unittest_setup.py
+++ b/_appmap/test/data/django/test/test_unittest_setup.py
@@ -1,0 +1,11 @@
+
+from unittest import TestCase
+
+from django.test import Client
+
+class DisabledRequestsRecordingTest(TestCase):
+    def setUp(self) -> None:
+        Client().get("/")
+
+    def test_request_in_setup(self):
+        pass

--- a/_appmap/test/test_django.py
+++ b/_appmap/test/test_django.py
@@ -201,11 +201,13 @@ class TestDjangoApp:
         # To really check middleware reset, the tests must run in order,
         # so disable randomly.
         result = pytester.runpytest("-svv", "-p", "no:randomly")
-        result.assert_outcomes(passed=4, failed=0, errors=0)
+        result.assert_outcomes(passed=5, failed=0, errors=0)
         # Look for the http_server_request event in test_app's appmap. If
         # middleware reset is broken, it won't be there.
         appmap_file = pytester.path / "tmp" / "appmap" / "pytest" / "test_request.appmap.json"
-        assert not os.path.exists(pytester.path / "tmp" / "appmap" / "requests")
+        assert not os.path.exists(
+            pytester.path / "tmp" / "appmap" / "requests"
+        ), "django tests generated request recordings"
 
         events = json.loads(appmap_file.read_text())["events"]
         assert "http_server_request" in events[0]
@@ -213,7 +215,7 @@ class TestDjangoApp:
     def test_disabled(self, pytester, monkeypatch):
         monkeypatch.setenv("_APPMAP", "false")
         result = pytester.runpytest("-svv", "-p", "no:randomly", "-k", "test_request")
-        result.assert_outcomes(passed=1, failed=0, errors=0)
+        result.assert_outcomes(passed=2, failed=0, errors=0)
         assert not (pytester.path / "tmp").exists()
 
     def test_disabled_for_process(self, pytester, monkeypatch):
@@ -223,7 +225,7 @@ class TestDjangoApp:
 
         # There are two tests for remote recording. They should both fail,
         # because process recording should disable remote recording.
-        result.assert_outcomes(passed=2, failed=2, errors=0)
+        result.assert_outcomes(passed=3, failed=2, errors=0)
 
         assert (pytester.path / "tmp" / "appmap" / "process").exists()
         assert not (pytester.path / "tmp" / "appmap" / "requests").exists()


### PR DESCRIPTION
Fixes #332

- Hooks `unittest` `TestCase._callSetUp` method to disable request recording in order to prevent the creation of a request recording when a request is made inside `setUp` method of a `unittest` test.
- Adds a `unittest` test to `django` fixture project which makes a request inside `setUp` method. This test makes the `test_django.py::TestDjangoApp::test_enabled` pass with the fix and fail without the fix.
- This edge case can be observed in this test in `django` project:
   `$ APPMAP=TRUE ./runtests.py auth_tests.test_views.ChangelistTests.test_user_change_email`
A request made inside `ChangelistTests.setUp` method leads to the creation of requests recording AppMap without the fix.
