### PR TITLE
fix: appmap breaks vscode python extension starting a REPL

### DIFF
--- a/ci/readonly-mount-appmap.log
+++ b/ci/readonly-mount-appmap.log
@@ -1,0 +1,1 @@
+# For a test in smoketest

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -6,4 +6,5 @@ docker run -q -i${t} --rm\
   -v $PWD/dist:/dist -v $PWD/_appmap/test/data/unittest:/_appmap/test/data/unittest\
   -v $PWD/ci:/ci\
   -w /tmp\
+  -v $PWD/ci/readonly-mount-appmap.log:/tmp/appmap.log:ro\
   python:3.11 bash -ce "${@:-/ci/smoketest.sh; /ci/test_pipenv.sh; /ci/test_poetry.sh}"

--- a/ci/smoketest.sh
+++ b/ci/smoketest.sh
@@ -19,6 +19,22 @@ EOF
   fi
 }
 
+test_log_file_not_writable()
+{
+  cat <<EOF > test_log_file_not_writable.py
+import appmap
+EOF
+
+  python test_log_file_not_writable.py
+
+  if [[ $? -eq 0 ]]; then
+    echo 'Script executed successfully'
+  else
+    echo 'Script execution failed'
+    exit 1
+  fi
+}
+
 set -ex
 pip -q install -U pip pytest "flask>=2,<3" python-decouple
 pip -q install /dist/appmap-*-py3-none-any.whl
@@ -49,3 +65,5 @@ else
   find $PWD
   exit 1
 fi
+
+test_log_file_not_writable


### PR DESCRIPTION
Fixes #339.

- Tolerates the inability to create the `appmap.log` file for logging, since a file system read-only error can occur in the [VSCode Python Extension, Virtual Environment, REPL, Shift Enter] scenario when attempting to create the log file.
- Mounts a read-only `appmap.log` file to Docker and adds a test to the smoke test suite for running with a non-modifiable `appmap.log`.