### PR TITLE
fix: bad appmaps in django oscar

### DIFF
--- a/appmap/django.py
+++ b/appmap/django.py
@@ -224,12 +224,20 @@ class Middleware(AppmapMiddleware):
             self.on_exception(rec, start, call_event_id, sys.exc_info())
             raise
 
+        # response.headers attribute is missing here while running some
+        # django-oscar project tests. There is a response._header attribute
+        # instead.
+        #   django-oscar commit hash: 9574ce2a56f3d99836c2e20785c116da12af6c42
+        #   example test: tests/functional/dashboard/test_dashboard.py
+        #                 TestDashboardIndexForAnonUser::test_is_not_available
+        headers = getattr(response, 'headers', getattr(response, '_headers', None))
+
         self.after_request_hook(
             request.path_info,
             request.method,
             request.build_absolute_uri(),
             response.status_code,
-            response.headers,
+            headers,
             start,
             call_event_id,
         )


### PR DESCRIPTION
- Modifies Django `Middleware` to work when there is no `headers` attribute in the response, but there is a `_headers` attribute instead. This issue was observed while running Django Oscar tests with AppMap Python on a specific version (git commit hash: 9574ce2a56f3d99836c2e20785c116da12af6c42) of Django Oscar.
- Adds a test to ensure that `Middleware.__call__` works when `get_response` returns a response with a `_headers` attribute instead of `headers`.