### PR TITLE
fix: bad appmaps in pytest project tests

### DIFF
--- a/_appmap/instrument.py
+++ b/_appmap/instrument.py
@@ -101,7 +101,12 @@ def call_instrumented(f, instance, args, kwargs):
         return ret
     except AppMapLimitExceeded:
         raise
-    except Exception:  # noqa: E722
+    # Some applications make use of exceptions that aren't descended from Exception. For example,
+    # pytest's OutcomeException, used to indicate the outcome of a test case, is a child of
+    # BaseException.
+    #
+    # We need to catch *any* exception raised, to ensure that we add the appropriate ExceptionEvent.
+    except BaseException:  # noqa: E722
         elapsed_time = time.time() - start_time
         Recorder.add_event(
             event.ExceptionEvent(

--- a/_appmap/test/data/example_class.py
+++ b/_appmap/test/data/example_class.py
@@ -5,6 +5,7 @@ and called. Used for testing appmap instrumentation.
 
 import time
 from functools import lru_cache, wraps
+from typing import NoReturn
 
 import appmap
 
@@ -155,6 +156,8 @@ class ExampleClass(Super, ClassMethodMixin):
 
     write_only = property(None, set_write_only, del_write_only, "Write-only")
 
+    def raise_base_exception(self) -> NoReturn:
+        raise BaseException("not derived from Exception") # pylint: disable=broad-exception-raised
 
 def modfunc():
     return "Hello world!"

--- a/_appmap/test/data/pytest-instrumented/appmap.yml
+++ b/_appmap/test/data/pytest-instrumented/appmap.yml
@@ -1,0 +1,12 @@
+name: Simple
+packages:
+- path: simple
+- path: _pytest
+  exclude:
+  # - _py.path
+  - compat.safe_getattr
+  - config.PytestPluginManager
+  - fixtures.getfixturemarker
+  - config.argparsing
+  - config.Config.rootpath
+- path: pytest

--- a/_appmap/test/data/pytest-instrumented/init/sitecustomize.py
+++ b/_appmap/test/data/pytest-instrumented/init/sitecustomize.py
@@ -1,0 +1,1 @@
+import appmap

--- a/_appmap/test/data/pytest-instrumented/test_instrumented.py
+++ b/_appmap/test/data/pytest-instrumented/test_instrumented.py
@@ -1,0 +1,16 @@
+import pytest
+
+# Copied from pytest-dev/pytest. When recorded, this test case will raise an OutcomeException
+# (specifically _pytest.outcomes.Skipped).
+def test_skipped(pytester):
+    pytester.makeconftest(
+        """
+        import pytest
+        def pytest_ignore_collect():
+            pytest.skip("intentional")
+    """
+    )
+    pytester.makepyfile("def test_hello(): pass")
+    result = pytester.runpytest_inprocess()
+    assert result.ret == pytest.ExitCode.NO_TESTS_COLLECTED
+    result.stdout.fnmatch_lines(["*1 skipped*"])

--- a/_appmap/test/helpers.py
+++ b/_appmap/test/helpers.py
@@ -44,7 +44,19 @@ def check_call_stack(events):
         if e.get("event") == "call":
             stack.append(e)
         elif e.get("event") == "return":
-            assert len(stack) > 0, "return without call"
+            assert len(stack) > 0, f"return without call, {e.get('id')}"
             call = stack.pop()
-            assert call.get("id") == e.get("parent_id")
-    assert len(stack) == 0, "leftover events"
+            assert call.get("id") == e.get(
+                "parent_id"
+            ), f"parent mismatch, {call.get('id')} != {e.get('parent_id')}"
+    assert len(stack) == 0, f"leftover events, {len(stack)}"
+
+
+if __name__ == "__main__":
+    import json
+    from pathlib import Path
+    import sys
+
+    with Path(sys.argv[1]).open(encoding="utf-8") as f:
+        appmap = json.load(f)
+        check_call_stack(appmap["events"])


### PR DESCRIPTION
- Catching `Exception` in the `instrument.py::call_instrumented` function to create exception return event, does not catch the `Skipped` exception raised from the `pytest.skip` function when the `pytest` library is instrumented because the `Skipped` exception is derived from `BaseException` but not from `Exception`. This leads to the bad AppMap due to the missing return event for the instrumented `pytest.skip` function.

- This fixes the problem by catching `BaseException`, the root class of the exception hierarchy, in `call_instrumented` function to be able to create the exception return event even if the instrumented function raises an exception not derived from the `Exception` class.

- Adds a test that records a method raising a `BaseException` which fails with producing a bad AppMap (unbalanced call order, missing exception return event) without the fix, and passes with the fix.