### PR TITLE
fix: Flask event ordering

### DIFF
--- a/_appmap/env.py
+++ b/_appmap/env.py
@@ -39,6 +39,8 @@ class Env(metaclass=SingletonMeta):
 
         self.log_file_creation_failed = False
         self._configure_logging()
+        # This uses _APPMAP, rather than APPMAP, to control whether instrumentation is enabled. The
+        # tests use this split to make it easier to control recording.
         enabled = self._env.get("_APPMAP", "false")
         self._enabled = enabled is None or enabled.lower() != "false"
 

--- a/_appmap/event.py
+++ b/_appmap/event.py
@@ -94,7 +94,8 @@ def _describe_schema(name, val, depth, max_depth):
     if islist:
         elts = [(None, v) for v in val]
         schema_key = "items"
-    elif isdict:
+    else:
+        assert isdict
         elts = val.items()
         schema_key = "properties"
 

--- a/_appmap/event.py
+++ b/_appmap/event.py
@@ -480,18 +480,19 @@ class HttpResponseEvent(ReturnEvent):
 
     def __init__(self, status_code, headers=None, **kwargs):
         super().__init__(**kwargs)
+        self.response = {}
+        self.update(status_code, headers)
 
-        response = {"status_code": status_code}
+    def update(self, status_code, headers):
+        if status_code is not None:
+            self.response.update({"status_code": status_code})
 
         if headers is not None:
-            response.update(
-                {
-                    "mime_type": headers.get("Content-Type"),
-                    "headers": none_if_empty(dict(headers)),
-                }
-            )
-
-        self.response = compact_dict(response)
+            if "Content-Type" in headers:
+                self.response.update({"mime_type": headers.get("Content-Type")})
+            updated_headers = dict(headers)
+            if len(updated_headers) > 0:
+                self.response.update({"headers": updated_headers})
 
 
 # pylint: disable=too-few-public-methods

--- a/_appmap/recorder.py
+++ b/_appmap/recorder.py
@@ -114,7 +114,8 @@ class Recorder(ABC):
     def check_time(cls, event_time):
         if _MAX_TIME is None:
             return
-        if event_time - cls.get_current()._start_time > _MAX_TIME:
+        delta = event_time - cls.get_current()._start_time  # pylint: disable=protected-access
+        if delta > _MAX_TIME:
             raise AppMapSessionTooLong(f"Session exceeded {_MAX_TIME} seconds")
 
     @classmethod

--- a/_appmap/test/conftest.py
+++ b/_appmap/test/conftest.py
@@ -2,7 +2,7 @@ import importlib
 import os
 import socket
 import sys
-from distutils.dir_util import copy_tree
+from shutil import copytree
 from functools import partial, partialmethod
 from pathlib import Path
 from typing import Any
@@ -98,7 +98,7 @@ def git_directory_fixture(tmp_path_factory):
 
 @pytest.fixture(name="git")
 def tmp_git(git_directory, tmp_path):
-    copy_tree(git_directory, str(tmp_path))
+    copytree(git_directory, str(tmp_path), dirs_exist_ok=True)
     return utils.git(cwd=tmp_path)
 
 

--- a/_appmap/test/conftest.py
+++ b/_appmap/test/conftest.py
@@ -14,7 +14,7 @@ from xprocess import ProcessStarter
 
 import _appmap
 import appmap
-from _appmap.test.web_framework import TEST_HOST, TEST_PORT
+from _appmap.test.web_framework import TEST_HOST
 from appmap import generation
 
 from .. import utils
@@ -198,14 +198,22 @@ def server_starter(info, name, cmd, pattern, env=None):
 
     return _starter
 
+@pytest.fixture(name="server_port")
+def server_port_fixture(worker_id):
+    if worker_id == "master":
+        offset = "0"
+    else:
+        offset = worker_id[2:]
+    return 8000 + int(offset)
+
 
 @pytest.fixture(name="server_base")
-def server_base_fixture(request):
+def server_base_fixture(request, server_port):
     marker = request.node.get_closest_marker("server")
     debug = marker.kwargs.get("debug", False)
     server_env = os.environ.copy()
     server_env.update(marker.kwargs.get("env", {}))
 
-    info = ServerInfo(debug=debug, host=TEST_HOST, port=TEST_PORT, env=server_env)
+    info = ServerInfo(debug=debug, host=TEST_HOST, port=server_port, env=server_env)
     info.factory = partial(server_starter, info)
     return info

--- a/_appmap/test/conftest.py
+++ b/_appmap/test/conftest.py
@@ -217,3 +217,36 @@ def server_base_fixture(request, server_port):
     info = ServerInfo(debug=debug, host=TEST_HOST, port=server_port, env=server_env)
     info.factory = partial(server_starter, info)
     return info
+
+@pytest.fixture(name="testdir")
+def testdir_fixture(request, data_dir, pytester, monkeypatch):
+    # We need to set environment variables to control how tests are run. This will only work
+    # properly if pytester runs pytest in a subprocess.
+    assert (
+        pytester._method == "subprocess"  # pylint:disable=protected-access
+    ), "must run pytest in a subprocess"
+
+    # The init subdirectory contains a sitecustomize.py file that
+    # imports the appmap module. This simulates the way a real
+    # installation works, performing the same function as the the
+    # appmap.pth file that gets put in site-packages.
+    monkeypatch.setenv("PYTHONPATH", "init")
+
+    # Make sure _APPMAP isn't in the environment, to test that recording-by-default is working as
+    # expected. Individual test cases may set it as necessary.
+    monkeypatch.delenv("_APPMAP", raising=False)
+
+    marker = request.node.get_closest_marker("example_dir")
+    test_type = "unittest" if marker is None else marker.args[0]
+    pytester.copy_example(test_type)
+
+    pytester.expected = data_dir / test_type / "expected"
+    pytester.test_type = test_type
+
+    # this is so test_type can be overriden in test cases
+    def output_dir():
+        return pytester.path / "tmp" / "appmap" / pytester.test_type
+
+    pytester.output = output_dir
+
+    return pytester

--- a/_appmap/test/data/flask-instrumented/appmap.yml
+++ b/_appmap/test/data/flask-instrumented/appmap.yml
@@ -1,0 +1,4 @@
+name: FlaskTest
+packages:
+- path: flaskapp
+- path: flask

--- a/_appmap/test/data/flask-instrumented/flaskapp.py
+++ b/_appmap/test/data/flask-instrumented/flaskapp.py
@@ -1,0 +1,30 @@
+"""
+Rudimentary Flask application for testing.
+"""
+# pylint: disable=missing-function-docstring
+
+import werkzeug
+from appmap.flask import AppmapFlask
+from flask import Flask, request
+
+app = Flask(__name__)
+AppmapFlask(app).init_app()
+
+
+@app.route("/")
+def hello_world():
+    return "Hello, World!"
+
+@app.route("/exception")
+def raise_exception():
+    raise Exception("An exception")
+
+@app.post("/do_post")
+def do_post():
+    _ = request.get_json()
+    return "Got post request"
+
+
+@app.errorhandler(werkzeug.exceptions.BadRequest)
+def handle_bad_request(e):
+    return "That's a bad request!", 400

--- a/_appmap/test/data/flask-instrumented/init/sitecustomize.py
+++ b/_appmap/test/data/flask-instrumented/init/sitecustomize.py
@@ -1,0 +1,1 @@
+import appmap

--- a/_appmap/test/data/flask-instrumented/test_app.py
+++ b/_appmap/test/data/flask-instrumented/test_app.py
@@ -13,6 +13,11 @@ def test_request(client):
 
     assert response.status_code == 200
 
+def test_exception(client):
+    response = client.get("/exception")
+
+    assert response.status_code == 500
+
 def test_not_found(client):
     response = client.get("/not_found")
 

--- a/_appmap/test/data/flask/flaskapp.py
+++ b/_appmap/test/data/flask/flaskapp.py
@@ -6,8 +6,9 @@ testing of record-by-default.
 """
 # pylint: disable=missing-function-docstring
 
-from flask import Flask, make_response
+from flask import Flask, make_response, request
 from markupsafe import escape
+import werkzeug
 
 app = Flask(__name__)
 
@@ -50,3 +51,13 @@ def show_org_user_posts(org, username):
 @app.route("/exception")
 def raise_exception():
     raise Exception("An exception")
+
+@app.post("/do_post")
+def do_post():
+    _ = request.get_json()
+    return "Got post request"
+
+
+@app.errorhandler(werkzeug.exceptions.BadRequest)
+def handle_bad_request(e):
+    return "That's a bad request!", 400

--- a/_appmap/test/helpers.py
+++ b/_appmap/test/helpers.py
@@ -1,6 +1,11 @@
 """Test helpers"""
 
 
+import importlib.metadata
+
+from packaging import version as pkg_version
+
+
 class DictIncluding(dict):
     """A dict that on comparison just checks whether the other dict includes
     all of its items. Any extra ones are ignored.
@@ -26,3 +31,20 @@ class HeadersIncluding(dict):
             if v is None:
                 return False
         return True
+
+
+def package_version(pkg):
+    return pkg_version.parse(importlib.metadata.version(pkg))
+
+
+def check_call_stack(events):
+    """Ensure that the call stack in events has balanced call and return events"""
+    stack = []
+    for e in events:
+        if e.get("event") == "call":
+            stack.append(e)
+        elif e.get("event") == "return":
+            assert len(stack) > 0, "return without call"
+            call = stack.pop()
+            assert call.get("id") == e.get("parent_id")
+    assert len(stack) == 0, "leftover events"

--- a/_appmap/test/test_command.py
+++ b/_appmap/test/test_command.py
@@ -1,6 +1,6 @@
 import json
 import re
-from distutils.dir_util import copy_tree
+from shutil import copytree
 from importlib.metadata import version
 
 import pytest
@@ -14,7 +14,7 @@ from .helpers import DictIncluding
 @pytest.fixture(name="_cmd_setup")
 def _cmd_setup(request, git, data_dir, monkeypatch):
     repo_root = git.cwd
-    copy_tree(data_dir / request.param, str(repo_root))
+    copytree(data_dir / request.param, str(repo_root), dirs_exist_ok=True)
     monkeypatch.chdir(repo_root)
 
     # pylint: disable=protected-access

--- a/_appmap/test/test_configuration.py
+++ b/_appmap/test/test_configuration.py
@@ -2,7 +2,7 @@
 # pylint: disable=missing-function-docstring
 
 from contextlib import contextmanager
-from distutils.dir_util import copy_tree
+from shutil import copytree
 from pathlib import Path
 from textwrap import dedent
 
@@ -154,7 +154,7 @@ class DefaultHelpers:
 class TestDefaultConfig(DefaultHelpers):
     def test_created(self, git, data_dir, monkeypatch):
         repo_root = git.cwd
-        copy_tree(data_dir / "config", str(repo_root))
+        copytree(data_dir / "config", str(repo_root), dirs_exist_ok=True)
         monkeypatch.chdir(repo_root)
 
         # pylint: disable=protected-access
@@ -163,7 +163,7 @@ class TestDefaultConfig(DefaultHelpers):
         self.check_default_config(repo_root.name)
 
     def test_created_outside_repo(self, data_dir, tmpdir, monkeypatch):
-        copy_tree(data_dir / "config", str(tmpdir))
+        copytree(data_dir / "config", str(tmpdir), dirs_exist_ok=True)
         monkeypatch.chdir(tmpdir)
 
         # pylint: disable=protected-access
@@ -180,7 +180,7 @@ class TestDefaultConfig(DefaultHelpers):
         assert not appmap.enabled()
 
     def test_exclusions(self, data_dir, tmpdir, mocker, monkeypatch):
-        copy_tree(data_dir / "config-exclude", str(tmpdir))
+        copytree(data_dir / "config-exclude", str(tmpdir), dirs_exist_ok=True)
         monkeypatch.chdir(tmpdir)
         mocker.patch(
             "_appmap.configuration._get_sys_prefix",
@@ -193,7 +193,7 @@ class TestDefaultConfig(DefaultHelpers):
 
     def test_created_if_missing_and_enabled(self, git, data_dir, monkeypatch, tmpdir):
         repo_root = git.cwd
-        copy_tree(data_dir / "config", str(repo_root))
+        copytree(data_dir / "config", str(repo_root), dirs_exist_ok=True)
         monkeypatch.chdir(repo_root)
 
         path = Path(repo_root / "appmap.yml")
@@ -213,7 +213,7 @@ class TestDefaultConfig(DefaultHelpers):
 
     def test_not_created_if_missing_and_not_enabled(self, git, data_dir, monkeypatch):
         repo_root = git.cwd
-        copy_tree(data_dir / "config", str(repo_root))
+        copytree(data_dir / "config", str(repo_root), dirs_exist_ok=True)
         monkeypatch.chdir(repo_root)
 
         path = Path(repo_root / "appmap.yml")
@@ -229,7 +229,7 @@ class TestDefaultConfig(DefaultHelpers):
 class TestEmpty(DefaultHelpers):
     @pytest.fixture(autouse=True)
     def setup_config(self, data_dir, monkeypatch, tmpdir):
-        copy_tree(data_dir / "config", str(tmpdir))
+        copytree(data_dir / "config", str(tmpdir), dirs_exist_ok=True)
         monkeypatch.chdir(tmpdir)
 
     @contextmanager
@@ -269,7 +269,7 @@ class TestSearchConfig:
     # pylint: disable=too-many-arguments
 
     def test_config_in_parent_folder(self, data_dir, tmpdir, monkeypatch):
-        copy_tree(data_dir / "config-up", str(tmpdir))
+        copytree(data_dir / "config-up", str(tmpdir), dirs_exist_ok=True)
         wd = tmpdir / "project" / "p1"
         monkeypatch.chdir(wd)
 
@@ -279,8 +279,8 @@ class TestSearchConfig:
         assert str(Env.current.output_dir).endswith(str(tmpdir / "tmp" / "appmap"))
 
     def _init_repo(self, data_dir, tmpdir, git_directory, repo_root, appmapdir):
-        copy_tree(data_dir / "config-up", str(tmpdir))
-        copy_tree(git_directory, str(repo_root))
+        copytree(data_dir / "config-up", str(tmpdir), dirs_exist_ok=True)
+        copytree(git_directory, str(repo_root), dirs_exist_ok=True)
         with open(appmapdir / "appmap.yml", "w+", encoding="utf-8") as f:
             f.writelines(
                 dedent("""
@@ -325,7 +325,7 @@ class TestSearchConfig:
         assert Env.current.enabled
 
     def test_config_not_found_in_path_hierarchy(self, data_dir, tmpdir, monkeypatch):
-        copy_tree(data_dir / "config-up", str(tmpdir))
+        copytree(data_dir / "config-up", str(tmpdir), dirs_exist_ok=True)
         wd = tmpdir / "project" / "p1"
         monkeypatch.chdir(wd)
 

--- a/_appmap/test/test_django.py
+++ b/_appmap/test/test_django.py
@@ -171,9 +171,6 @@ def test_exception(client, events, monkeypatch):
 
     assert events[1].event == "return"
     assert events[1].parent_id == events[0].id
-    assert events[1].exceptions == [
-        DictIncluding({"class": "builtins.RuntimeError", "message": "An error"})
-    ]
 
 
 @pytest.mark.appmap_enabled(env={"APPMAP_RECORD_REQUESTS": "false"})

--- a/_appmap/test/test_django_simplelazyobject.py
+++ b/_appmap/test/test_django_simplelazyobject.py
@@ -16,7 +16,8 @@ def test_recording_simplelazyobject_does_not_evaluate():
     doesn't cause incorrect premature evaluation.
     """
     with appmap.Recording():
-        import appmap_testing.django_simplelazyobject as ecds  # pylint: disable=import-outside-toplevel
+        import appmap_testing.django_simplelazyobject as ecds  # pylint: disable=import-outside-toplevel, import-error
+
         ecds.lazy()
 
     # if we're here and the exception wasn't thrown, we're good

--- a/_appmap/test/test_events.py
+++ b/_appmap/test/test_events.py
@@ -45,7 +45,7 @@ class TestEvents:
     def test_recursion_protection(self):
         r = appmap.Recording()
         with r:
-            from example_class import ExampleClass
+            from example_class import ExampleClass  # pylint: disable=import-outside-toplevel
 
             ExampleClass().instance_method()
 
@@ -56,7 +56,7 @@ class TestEvents:
     def test_when_str_raises(self, mocker):
         r = appmap.Recording()
         with r:
-            from example_class import ExampleClass
+            from example_class import ExampleClass  # pylint: disable=import-outside-toplevel
 
             param = mocker.Mock()
             param.__str__ = mocker.Mock(side_effect=Exception)
@@ -72,7 +72,7 @@ class TestEvents:
     def test_when_both_raise(self, mocker):
         r = appmap.Recording()
         with r:
-            from example_class import ExampleClass
+            from example_class import ExampleClass  # pylint: disable=import-outside-toplevel
 
             param = mocker.Mock()
             param.__str__ = mocker.Mock(side_effect=Exception)
@@ -88,7 +88,7 @@ class TestEvents:
         Env.current.set("APPMAP_DISPLAY_PARAMS", "false")
         r = appmap.Recording()
         with r:
-            from example_class import ExampleClass
+            from example_class import ExampleClass  # pylint: disable=import-outside-toplevel
 
             param = mocker.MagicMock()
 

--- a/_appmap/test/test_fastapi.py
+++ b/_appmap/test/test_fastapi.py
@@ -24,6 +24,10 @@ class TestRecordRequests(_TestRecordRequests):
 
 @pytest.mark.app(remote_enabled=True)
 class TestRemoteRecording(_TestRemoteRecording):
+    def __init__(self):
+        self.expected_thread_id = None
+        self.expected_content_type = None
+
     def setup_method(self):
         self.expected_thread_id = 1
         self.expected_content_type = "application/json"
@@ -39,7 +43,7 @@ def fastapi_app(data_dir, monkeypatch, request):
 
     Env.current.set("APPMAP_CONFIG", data_dir / "fastapi" / "appmap.yml")
 
-    from fastapiapp import main  # pyright: ignore[reportMissingImports]
+    from fastapiapp import main  # pyright: ignore[reportMissingImports] pylint: disable=import-error,import-outside-toplevel
 
     importlib.reload(main)
 

--- a/_appmap/test/test_flask.py
+++ b/_appmap/test/test_flask.py
@@ -14,7 +14,7 @@ from _appmap.env import Env
 from _appmap.metadata import Metadata
 from appmap.flask import AppmapFlask
 
-from ..test.helpers import DictIncluding, check_call_stack, package_version
+from ..test.helpers import DictIncluding, check_call_stack
 from .web_framework import (
     _TestFormCapture,
     _TestFormData,
@@ -212,8 +212,8 @@ class TestFlaskApp:
         assert not (pytester.path / "tmp" / "appmap" / "pytest").exists()
 
 def verify_events(events):
-    def find(type):
-        return next(filter(lambda e: e[1].get(type) is not None, enumerate(events)), None)
+    def find(event_type):
+        return next(filter(lambda e: e[1].get(event_type) is not None, enumerate(events)), None)
 
     request = find("http_server_request")
     assert request is not None

--- a/_appmap/test/test_params.py
+++ b/_appmap/test/test_params.py
@@ -58,7 +58,7 @@ class TestMethodBase:
         of this fixture, unload it after.  This ensures that each test
         sees a pristine version of the classes it contains.
         """
-        from params import (  # pyright: ignore[reportMissingImports] pylint: disable=import-error
+        from params import (  # pyright: ignore[reportMissingImports] pylint: disable=import-error,import-outside-toplevel
             C,
         )
 

--- a/_appmap/test/test_recording.py
+++ b/_appmap/test/test_recording.py
@@ -3,13 +3,12 @@
 
 import json
 import os
-from distutils.dir_util import copy_tree
-from distutils.file_util import copy_file
+from shutil import copy, copytree
 from threading import Thread
 
+import appmap
 import pytest
 
-import appmap
 from _appmap.event import Event
 from _appmap.recorder import Recorder, ThreadRecorder
 from _appmap.wrapt import FunctionWrapper
@@ -193,9 +192,9 @@ class TestRecordingPerThread:
 def test_process_recording(data_dir, shell, tmp_path):
     fixture = data_dir / "package1"
     tmp = tmp_path / "process"
-    copy_tree(fixture, str(tmp / "package1"))
-    copy_file(data_dir / "appmap.yml", str(tmp))
-    copy_tree(data_dir / "flask" / "init", str(tmp / "init"))
+    copytree(fixture, str(tmp / "package1"), dirs_exist_ok=True)
+    copy(data_dir / "appmap.yml", str(tmp))
+    copytree(data_dir / "flask" / "init", str(tmp / "init"), dirs_exist_ok=True)
 
     ret = shell.run(
         "python",

--- a/_appmap/test/test_recording.py
+++ b/_appmap/test/test_recording.py
@@ -6,9 +6,9 @@ import os
 from shutil import copy, copytree
 from threading import Thread
 
-import appmap
 import pytest
 
+import appmap
 from _appmap.event import Event
 from _appmap.recorder import Recorder, ThreadRecorder
 from _appmap.wrapt import FunctionWrapper

--- a/appmap/django.py
+++ b/appmap/django.py
@@ -224,15 +224,23 @@ class Middleware(AppmapMiddleware):
             self.on_exception(rec, start, call_event_id, sys.exc_info())
             raise
 
-        self.after_request_hook(
+        return_event = self.after_request_main(
             request.path_info,
-            request.method,
-            request.build_absolute_uri(),
             response.status_code,
             response.headers,
             start,
             call_event_id,
         )
+
+        if return_event is not None:
+            self.after_request_hook(
+                request.path_info,
+                request.method,
+                request.build_absolute_uri(),
+                response.status_code,
+                response.headers,
+                return_event,
+            )
 
         return response
 

--- a/appmap/fastapi.py
+++ b/appmap/fastapi.py
@@ -117,15 +117,23 @@ class Middleware(AppmapMiddleware, BaseHTTPMiddleware):
 
         parsed = request.url.components
         baseurl = urlunparse((parsed.scheme, parsed.netloc, parsed.path, "", "", ""))
-        self.after_request_hook(
+        return_event = self.after_request_main(
             request.url.path,
-            request.method,
-            baseurl,
             response.status_code,
             response.headers,
             start,
             call_event_id,
         )
+        if return_event is not None:
+            self.after_request_hook(
+                request.url.path,
+                request.method,
+                baseurl,
+                response.status_code,
+                response.headers,
+                return_event,
+            )
+
         return response
 
     async def _parse_json(self, request):

--- a/pylintrc
+++ b/pylintrc
@@ -1,6 +1,6 @@
 [MAIN]
 # Specify a score threshold under which the program will exit with error.
-fail-under=9.94
+fail-under=9.99
 
 
 # Analyse import fallback blocks. This can be used to support both Python 2 and

--- a/pylintrc
+++ b/pylintrc
@@ -1,6 +1,6 @@
 [MAIN]
 # Specify a score threshold under which the program will exit with error.
-fail-under=9.86
+fail-under=9.87
 
 
 # Analyse import fallback blocks. This can be used to support both Python 2 and

--- a/pylintrc
+++ b/pylintrc
@@ -1,6 +1,6 @@
 [MAIN]
 # Specify a score threshold under which the program will exit with error.
-fail-under=9.87
+fail-under=9.94
 
 
 # Analyse import fallback blocks. This can be used to support both Python 2 and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,8 @@ fastapi = "^0.110.0"
 httpx = "^0.27.0"
 pytest-env = "^1.1.3"
 pytest-console-scripts = "^1.4.1"
+pytest-xdist = "^3.6.1"
+psutil = "^6.0.0"
 
 [build-system]
 requires = ["poetry-core>=1.1.0"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,9 +10,10 @@ markers =
 testpaths = _appmap/test
 pytester_example_dir = _appmap/test/data
 
-# running in a subprocess ensures that environment variables are set
-# correctly and no classes are loaded.
-addopts = --runpytest subprocess --ignore vendor
+# running in a subprocess ensures that environment variables are set correctly and no classes are
+# loaded. Also, the remote-recording tests can't be run in parallel, so they're marked to run in the
+# same load group and distribution is done by loadgroup.
+addopts = --runpytest subprocess --ignore vendor --tb=short --dist loadgroup
 
 # We're stuck at pytest ~6.1.2. This warning got removed in a later
 # version.

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,7 @@ skip_install = True
 deps =
     poetry
     {[web-deps]deps}
+    numpy >=2
 commands =
     poetry install
     # It doesn't seem great to disable cyclic-import checking, but the imports

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,8 @@ deps=
     sqlalchemy >=2.0, <3.0
 
 [testenv]
+passenv = 
+    PYTEST_XDIST_AUTO_NUM_WORKERS
 allowlist_externals =
     env
     bash
@@ -26,10 +28,10 @@ deps=
 
 commands =
     poetry install -v
-    web: poetry run appmap-python {posargs:pytest}
-    django3: poetry run appmap-python pytest _appmap/test/test_django.py
-    flask2: poetry run appmap-python pytest _appmap/test/test_flask.py
-    sqlalchemy1: poetry run appmap-python pytest _appmap/test/test_sqlalchemy.py
+    web: poetry run appmap-python {posargs:pytest -n logical}
+    django3: poetry run appmap-python pytest -n logical _appmap/test/test_django.py
+    flask2: poetry run appmap-python pytest -n logical _appmap/test/test_flask.py
+    sqlalchemy1: poetry run appmap-python pytest -n logical _appmap/test/test_sqlalchemy.py
 
 [testenv:lint]
 skip_install = True


### PR DESCRIPTION
Currently, if the config specifies that `flask` should be instrumented, an `http_server_response` event gets recorded between the `call` and `return` events for `Flask` functions. Also, a `return` event with an exception will get recorded between the `call` and `return` events for different `Flask`.

These changes hook `finalize_request` and `handle_user_exception`, and ensuring that the events get ordered correctly.

Fixes #341
