### PR TITLE
fix: disable property instrumentation by default

### DIFF
--- a/_appmap/importer.py
+++ b/_appmap/importer.py
@@ -167,7 +167,7 @@ class Importer:
         cls.filter_chain = []
         cls._skip_instrumenting = ("appmap", "_appmap")
         cls.instrument_properties = (
-            Env.current.get("APPMAP_INSTRUMENT_PROPERTIES", "true").lower() == "true"
+            Env.current.get("APPMAP_INSTRUMENT_PROPERTIES", "false").lower() == "true"
         )
 
     @classmethod

--- a/_appmap/test/test_properties.py
+++ b/_appmap/test/test_properties.py
@@ -5,10 +5,7 @@
 import pytest
 from _appmap.test.helpers import DictIncluding
 
-pytestmark = [
-    pytest.mark.appmap_enabled,
-]
-
+pytestmark = pytest.mark.skip(reason="property instrumentation is broken in Django")
 
 @pytest.fixture(autouse=True)
 def setup(with_data_dir):  # pylint: disable=unused-argument


### PR DESCRIPTION
Disable property instrumentation until it works properly for Django.