### PR TITLE
disable parameter rendering by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,16 +90,15 @@ Note that you must install the dependencies contained in
 [requirements-dev.txt](requirements-dev.txt) before running tests. See the explanation in
 [pyproject.toml](pyproject.toml) for details.
 
-Additionally, the tests currently require that you set `APPMAP=true`. You can
-either run `pytest` with `appmap-python` (see [tox.ini](tox.ini)), or you can explicitly
-set the environment variable.
+Additionally, the tests currently require that you set `APPMAP=true` and
+`APPMAP_DISPLAY_PARAMS=true`. 
 
 [pytest](https://docs.pytest.org/en/stable/) for testing:
 
 ```
 % cd appmap-python
 % pip install -r requirements-test.txt
-% poetry run pytest
+% APPMAP=true APPMAP_DISPLAY_PARAMS=true poetry run pytest
 ```
 
 ### tox

--- a/_appmap/env.py
+++ b/_appmap/env.py
@@ -39,13 +39,13 @@ class Env(metaclass=SingletonMeta):
 
         self.log_file_creation_failed = False
         self._configure_logging()
-        # This uses _APPMAP, rather than APPMAP, to control whether instrumentation is enabled. The
-        # tests use this split to make it easier to control recording.
-        enabled = self._env.get("_APPMAP", "false")
-        self._enabled = enabled is None or enabled.lower() != "false"
-
-        self._root_dir = str(self._cwd) + "/"
-        self._root_dir_len = len(self._root_dir)
+        # This uses the underscore-decorated, rather than the undecorated variants, to control
+        # whether these settings are enabled. The tests use this split to make it easier to control
+        # them.
+        enabled = self._env.get("_APPMAP", None)
+        self._enabled = enabled is not None and enabled.lower() != "false"
+        display_params = self._env.get("_APPMAP_DISPLAY_PARAMS", None)
+        self._display_params = display_params is not None and display_params.lower() != "false"
 
         logger = logging.getLogger(__name__)
         # The user shouldn't set APPMAP_OUTPUT_DIR, but some tests depend on being able to use it.
@@ -131,7 +131,7 @@ class Env(metaclass=SingletonMeta):
 
     @property
     def display_params(self):
-        return self.get("APPMAP_DISPLAY_PARAMS", "true").lower() == "true"
+        return self._display_params
 
     def getLogger(self, name) -> trace_logger.TraceLogger:
         return cast(trace_logger.TraceLogger, logging.getLogger(name))

--- a/_appmap/env.py
+++ b/_appmap/env.py
@@ -1,5 +1,6 @@
 """Initialize from the environment"""
 
+from functools import cached_property
 import logging
 import logging.config
 import os
@@ -69,13 +70,13 @@ class Env(metaclass=SingletonMeta):
     def delete(self, name):
         del self._env[name]
 
-    @property
+    @cached_property
     def root_dir(self):
-        return self._root_dir
+        return str(self._cwd) + "/"
 
-    @property
+    @cached_property
     def root_dir_len(self):
-        return self._root_dir_len
+        return len(self.root_dir)
 
     @property
     def output_dir(self):
@@ -123,7 +124,7 @@ class Env(metaclass=SingletonMeta):
             if value:
                 self.set(key, value)
 
-    @property
+    @cached_property
     def is_appmap_repo(self):
         return os.path.exists("appmap/__init__.py") and os.path.exists(
             "_appmap/__init__.py"

--- a/_appmap/test/conftest.py
+++ b/_appmap/test/conftest.py
@@ -68,6 +68,8 @@ def pytest_runtest_setup(item):
         elif appmap_enabled is None:
             env.pop("_APPMAP", None)
 
+    env["_APPMAP_DISPLAY_PARAMS"] = env.get("APPMAP_DISPLAY_PARAMS", "true")
+
     _appmap.initialize(env=env)  # pylint: disable=protected-access
 
     # Some tests want yaml instrumented, others don't.

--- a/_appmap/test/test_events.py
+++ b/_appmap/test/test_events.py
@@ -9,7 +9,6 @@ from threading import Thread
 import pytest
 
 import appmap
-from _appmap.env import Env
 from _appmap.event import _EventIds
 
 
@@ -84,8 +83,8 @@ class TestEvents:
         actual_value = r.events[0].parameters[0]["value"]
         assert re.fullmatch(expected_re, actual_value)
 
+    @pytest.mark.appmap_enabled(env={"APPMAP_DISPLAY_PARAMS": "false"})
     def test_when_display_disabled(self, mocker):
-        Env.current.set("APPMAP_DISPLAY_PARAMS", "false")
         r = appmap.Recording()
         with r:
             from example_class import ExampleClass  # pylint: disable=import-outside-toplevel

--- a/appmap/__init__.py
+++ b/appmap/__init__.py
@@ -11,8 +11,11 @@ _enabled = os.environ.get("APPMAP", None)
 _recording_exported = False
 if _enabled is None or _enabled.upper() == "TRUE":
     if _enabled is not None:
-        # Use setdefault so tests can manage _APPMAP as necessary
+        # Use setdefault so tests can manage settings as necessary
         os.environ.setdefault("_APPMAP", _enabled)
+        _display_params = os.environ.get("APPMAP_DISPLAY_PARAMS", "false")
+        os.environ.setdefault("_APPMAP_DISPLAY_PARAMS", _display_params)
+
         from _appmap import generation  # noqa: F401
         from _appmap.env import Env  # noqa: F401
         from _appmap.importer import instrument_module  # noqa: F401
@@ -52,8 +55,10 @@ if _enabled is None or _enabled.upper() == "TRUE":
             return Env.current.enabled
     else:
         os.environ.pop("_APPMAP", None)
+        os.environ.pop("_APPMAP_DISPLAY_PARAMS", None)
 else:
     os.environ.setdefault("_APPMAP", "false")
+    os.environ.setdefault("_APPMAP_DISPLAY_PARAMS", "false")
 
 if not _recording_exported:
     # Client code that imports appmap.Recording should run correctly

--- a/tox.ini
+++ b/tox.ini
@@ -13,10 +13,8 @@ deps=
 [testenv]
 passenv = 
     PYTEST_XDIST_AUTO_NUM_WORKERS
-allowlist_externals =
-    env
-    bash
-
+setenv = 
+    APPMAP_DISPLAY_PARAMS=true
 deps=
     poetry
     web: {[web-deps]deps}


### PR DESCRIPTION
By default, parameters will no longer be rendered as strings by default.
To see the values of parameters, APPMAP_DISPLAY_PARAMS must be set to
"true".

Fixes #360.
