### PR TITLE
fix: Prevent process recordings from clobbering one another

### DIFF
--- a/_appmap/recording.py
+++ b/_appmap/recording.py
@@ -115,7 +115,9 @@ def initialize():
             nonlocal r
             r.stop()
             now = datetime.now(timezone.utc)
-            appmap_name = now.isoformat(timespec="seconds").replace("+00:00", "Z")
+            iso_time = now.isoformat(timespec="seconds").replace("+00:00", "Z")
+            process_id = os.getpid()
+            appmap_name = f"{iso_time}_{process_id}"
             recorder_type = "process"
             metadata = {
                 "name": appmap_name,


### PR DESCRIPTION
This pull request addresses an issue where AppMap data output via process recordings could potentially clobber each other if multiple processes quit within the same second. 

#### Changes:
- The file name for AppMap data output now includes the process ID to prevent overwriting data when multiple processes finish execution simultaneously.

These changes ensure that each process's recordings are distinctly named, thereby avoiding data loss due to file overwriting.