### PR TITLE
ci: Update tox configuration to run Django5

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 isolated_build = true
 # The *-web environments test the latest versions of Django and Flask with the full test suite. For
 # older version of the web frameworks, just run the tests that are specific to them.
-envlist = py3{8,9,10,11,12}-{web,django3,flask2,sqlalchemy1},lint
+envlist = py3{8,9,10,11,12}-{web,django3,django4,django5,flask2,sqlalchemy1},lint
 
 [web-deps]
 deps=
@@ -22,12 +22,16 @@ deps=
     py3{9,10,11,12}: numpy >=2
     flask2: Flask >= 2.0, <3.0
     django3: Django >=3.2, <4.0
+    django4: Django >=4.0, <5.0
+    django5: Django >=5.0, <6.0
     sqlalchemy1: sqlalchemy >=1.4.11, <2.0
 
 commands =
     poetry install -v
     web: poetry run appmap-python {posargs:pytest -n logical}
     django3: poetry run appmap-python pytest -n logical _appmap/test/test_django.py
+    django4: poetry run appmap-python pytest -n logical _appmap/test/test_django.py
+    django5: poetry run appmap-python pytest -n logical _appmap/test/test_django.py
     flask2: poetry run appmap-python pytest -n logical _appmap/test/test_flask.py
     sqlalchemy1: poetry run appmap-python pytest -n logical _appmap/test/test_sqlalchemy.py
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 isolated_build = true
 # The *-web environments test the latest versions of Django and Flask with the full test suite. For
 # older version of the web frameworks, just run the tests that are specific to them.
-envlist = py3{8,9,10,11,12}-{web,django3,django4,django5,flask2,sqlalchemy1},lint
+envlist = py3{10,11,12}-{django5}, py3{8,9,10,11,12}-{web,django3,django4,flask2,sqlalchemy1},lint
 
 [web-deps]
 deps=


### PR DESCRIPTION
Attaching notes on the run, including test errors.

We should also see these in CI

Fixes https://github.com/getappmap/appmap-python/issues/373

Looks like this is still running on Travis -- https://app.travis-ci.com/github/getappmap/appmap-python/builds/273589597

Looks like the build matrix passed with Python >= 3.10. Django 5 is not supported with earlier Pythons, so that is probably why those tests failed. I'm sure Navie can help me figure out how to disable the Django5 tests with those older Pythons.

https://app.travis-ci.com/github/getappmap/appmap-python/builds/273589597

